### PR TITLE
Use GetScaledLevel in Validation Tests

### DIFF
--- a/src/Tests/OffsetValidationTests.cpp
+++ b/src/Tests/OffsetValidationTests.cpp
@@ -60,7 +60,7 @@ SCENARIO("Live Offset Validation in PvP Lobby", "[Offsets]")
                 CHECK(pos.x != 0.0f);
 
                 auto coreStats = localPlayer.GetCoreStats();
-                CHECK(coreStats.GetLevel() == 80);
+                CHECK(coreStats.GetScaledLevel() == 80);
                 CHECK(coreStats.GetProfession() != kx::Game::Profession::None);
                 CHECK(coreStats.GetRace() != kx::Game::Race::None);
 


### PR DESCRIPTION
The test was failing because it used GetLevel() instead of GetScaledLevel(). This change fixes it.

`OffsetValidationTests.cpp(63): failed: coreStats.GetLevel() == 80 for: 4 == 80 with 6 messages: '--- INSTRUCTIONS ---' and 'For these tests to pass, stand near the Siege Training Waypoint in the PvP Lobby.' and 'You should see two types of golems: hostile red ones, and neutral indifferent ones.' and 'Could not get ContextCollection. Are patterns outdated?' and 'Could not get Local Player pointer from ChCliContext.' and 'Position was (0,0,0). Are you fully loaded into the map?'`