### PR TITLE
Fix: Improve GW2AL Compatibility and Stability

### DIFF
--- a/src/Core/AppLifecycleManager.cpp
+++ b/src/Core/AppLifecycleManager.cpp
@@ -201,17 +201,16 @@ void AppLifecycleManager::CheckAndInitializeServices() {
 
 void AppLifecycleManager::RenderTick(HWND windowHandle, float displayWidth, float displayHeight,
     ID3D11DeviceContext* context, ID3D11RenderTargetView* renderTargetView) {
-    // Early exit if shutting down
+
     if (m_currentState == State::ShuttingDown) {
         return;
     }
 
-    // ADD THIS: Safety check for context and RTV
     if (!context || !renderTargetView) {
         return;
     }
 
-    // === Handle input (INSERT key toggle for UI visibility) ===
+    // Handle input for UI toggle
     static bool lastToggleKeyState = false;
     bool currentToggleKeyState = (GetAsyncKeyState(VK_INSERT) & 0x8000) != 0;
 
@@ -219,27 +218,24 @@ void AppLifecycleManager::RenderTick(HWND windowHandle, float displayWidth, floa
         bool isOpen = AppState::Get().IsVisionWindowOpen();
         AppState::Get().SetVisionWindowOpen(!isOpen);
     }
-
     lastToggleKeyState = currentToggleKeyState;
+
+    // Declare state backup here to ensure it's available in the catch block
+    StateBackupD3D11 d3dState;
 
     try {
         // CRITICAL: Backup D3D state before rendering
-        StateBackupD3D11 d3dState;
         BackupD3D11State(context, d3dState);
 
-        // Update MumbleLink every frame (it will auto-initialize on first call)
         m_mumbleLinkManager.Update();
         const MumbleLinkData* mumbleLinkData = m_mumbleLinkManager.GetData();
 
-        // Check and initialize services if ready (for GW2AL mode)
         CheckAndInitializeServices();
 
-        // Update camera with latest MumbleLink data
-        if (mumbleLinkData) { // Check if mumbleLinkData is valid before updating
+        if (mumbleLinkData) {
             m_camera.Update(mumbleLinkData, windowHandle);
         }
 
-        // Render ImGui UI
         ImGuiManager::NewFrame();
         ImGuiManager::RenderUI(m_camera, m_mumbleLinkManager, mumbleLinkData,
             windowHandle, displayWidth, displayHeight);
@@ -250,10 +246,8 @@ void AppLifecycleManager::RenderTick(HWND windowHandle, float displayWidth, floa
     }
     catch (...) {
         LOG_ERROR("Exception caught in RenderTick");
-        // Attempt to restore D3D state even if an exception occurs
-        StateBackupD3D11 emergencyState;
-        BackupD3D11State(context, emergencyState);
-        RestoreD3D11State(context, emergencyState);
+        // Attempt to restore the original D3D state to prevent a game crash
+        RestoreD3D11State(context, d3dState);
     }
 }
 

--- a/src/Core/Config.h
+++ b/src/Core/Config.h
@@ -5,7 +5,7 @@
 // ===== Build Configuration =====
 // Uncomment the line below to build for GW2AL (addon loader) mode.
 // Comment it out to build as a standalone DLL for manual injection.
-//#define GW2AL_BUILD
+#define GW2AL_BUILD
 // ==============================
 
 namespace kx {

--- a/src/Core/Config.h
+++ b/src/Core/Config.h
@@ -5,7 +5,7 @@
 // ===== Build Configuration =====
 // Uncomment the line below to build for GW2AL (addon loader) mode.
 // Comment it out to build as a standalone DLL for manual injection.
-#define GW2AL_BUILD
+//#define GW2AL_BUILD
 // ==============================
 
 namespace kx {

--- a/src/Core/GW2AL_Integration.cpp
+++ b/src/Core/GW2AL_Integration.cpp
@@ -49,29 +49,29 @@ void OnPresent(D3D9_wrapper_event_data* evd) {
     if (!kx::Hooking::D3DRenderHook::IsInitialized()) return;
     if (kx::AppState::Get().IsShuttingDown()) return;
 
-    // Extract the swap chain from the event data
-    IDXGISwapChain* pSwapChain = (IDXGISwapChain*)((void**)evd->stackPtr)[0];
+    // Correctly get the swapchain from the wrapped object
+    wrapped_com_obj* wrapObj = reinterpret_cast<wrapped_com_obj*>(evd->stackPtr[0]);
+    if (!wrapObj) return;
+
+    IDXGISwapChain* pSwapChain = wrapObj->orig_swc;
     if (!pSwapChain) return;
 
     auto* device = kx::Hooking::D3DRenderHook::GetDevice();
     auto* context = kx::Hooking::D3DRenderHook::GetContext();
     if (!device || !context) return;
 
-    // Create a render target view from the current back buffer
-    // NOTE: We create this every frame instead of caching because:
-    // 1. Ensures RTV is always valid and matches current back buffer size
-    // 2. Avoids stale cache issues after window resize
-    // 3. Performance impact is negligible (~120 API calls/sec is trivial for modern GPUs)
+    // Create a render target view from the current back buffer for robustness
     ID3D11Texture2D* pBackBuffer = nullptr;
     if (FAILED(pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBuffer))) return;
 
     ID3D11RenderTargetView* mainRenderTargetView = nullptr;
-    if (FAILED(device->CreateRenderTargetView(pBackBuffer, NULL, &mainRenderTargetView))) {
-        pBackBuffer->Release();
+    HRESULT hr = device->CreateRenderTargetView(pBackBuffer, NULL, &mainRenderTargetView);
+    pBackBuffer->Release();
+
+    if (FAILED(hr) || !mainRenderTargetView) {
         return;
     }
-    pBackBuffer->Release();
-    
+
     // Get display size from swap chain
     DXGI_SWAP_CHAIN_DESC sd;
     pSwapChain->GetDesc(&sd);
@@ -79,12 +79,50 @@ void OnPresent(D3D9_wrapper_event_data* evd) {
     float displayHeight = static_cast<float>(sd.BufferDesc.Height);
     HWND windowHandle = kx::Hooking::D3DRenderHook::GetWindowHandle();
 
-    // === Centralized per-frame tick (update + render) ===
-    // Note: D3D state backup/restore is handled inside RenderTick
+    // Centralized per-frame tick (update + render)
     kx::g_App.RenderTick(windowHandle, displayWidth, displayHeight, context, mainRenderTargetView);
 
-    // Clean up render target view
+    // Clean up the per-frame render target view
     mainRenderTargetView->Release();
+}
+
+void OnDXGIPostCreateSwapChain(D3D9_wrapper_event_data* evd) {
+    if (!evd || !evd->stackPtr) {
+        LOG_ERROR("[GW2AL] Invalid event data in OnDXGIPostCreateSwapChain");
+        return;
+    }
+
+    dxgi_CreateSwapChain_cp* params = reinterpret_cast<dxgi_CreateSwapChain_cp*>(evd->stackPtr);
+    if (!params->inDevice || !params->ppSwapchain || !*params->ppSwapchain) {
+        LOG_ERROR("[GW2AL] Null parameter in CreateSwapChain event");
+        return;
+    }
+
+    // Safely get the D3D11 device interface using QueryInterface
+    ID3D11Device* device = nullptr;
+    HRESULT hr = params->inDevice->QueryInterface(__uuidof(ID3D11Device), (void**)&device);
+
+    if (FAILED(hr) || !device) {
+        LOG_ERROR("[GW2AL] Failed to query D3D11Device interface: 0x%08X", hr);
+        return;
+    }
+
+    // Initialize with device and swap chain
+    bool initResult = kx::Hooking::D3DRenderHook::InitializeFromDevice(
+        device,
+        *params->ppSwapchain
+    );
+
+    // Always release our reference to the device
+    device->Release();
+
+    if (initResult) {
+        LOG_INFO("[GW2AL] D3DRenderHook initialized successfully");
+        kx::g_App.OnRendererInitialized();
+    }
+    else {
+        LOG_ERROR("[GW2AL] Failed to initialize D3DRenderHook");
+    }
 }
 
 /**
@@ -93,15 +131,21 @@ void OnPresent(D3D9_wrapper_event_data* evd) {
  * Called when the game window is resized. We need to update our render target.
  */
 void OnResize(D3D9_wrapper_event_data* evd) {
-    if (!evd || !evd->stackPtr) return;
-    if (!kx::Hooking::D3DRenderHook::IsInitialized()) return;
+    if (!evd || !evd->stackPtr) {
+        return;
+    }
+    if (!kx::Hooking::D3DRenderHook::IsInitialized()) {
+        return;
+    }
 
-    // Get the swap chain pointer from the event data (using shared struct from d3d9_wrapper_structs.h)
-    swc_ResizeBuffers_cp* params = (swc_ResizeBuffers_cp*)evd->stackPtr;
-    if (!params || !params->swc) return;
+    // Get the swap chain pointer from the event data
+    // Note: In a POST event, the parameters reflect the state AFTER the call.
+    swc_ResizeBuffers_cp* params = reinterpret_cast<swc_ResizeBuffers_cp*>(evd->stackPtr);
+    if (!params || !params->swc) {
+        return;
+    }
 
-    // Just recreate the RTV with the new back buffer size
-    // The dimensions from params may be unreliable in POST event
+    // Delegate to the D3DRenderHook to handle the resource cleanup.
     kx::Hooking::D3DRenderHook::OnResize(params->swc);
 }
 
@@ -140,58 +184,33 @@ extern "C" __declspec(dllexport) gw2al_api_ret gw2addon_load(gw2al_core_vtable* 
     g_al_api = core_api;
 
     LOG_INIT();
-    
-    // Setup debug console in debug builds
+
 #ifdef _DEBUG
     kx::SetupConsole();
 #endif
-    
+
     LOG_INFO("KXVision starting up in GW2AL mode...");
 
-    // Initialize the application lifecycle manager for GW2AL mode
     if (!kx::g_App.InitializeForGW2AL()) {
         LOG_ERROR("Failed to initialize AppLifecycleManager for GW2AL mode");
         return GW2AL_FAIL;
     }
 
-    // Get the function pointer from d3d9_wrapper to enable events
     pD3D9_wrapper_enable_event enable_event = (pD3D9_wrapper_enable_event)g_al_api->query_function(
         g_al_api->hash_name((wchar_t*)D3D9_WRAPPER_ENABLE_EVENT_FNAME)
     );
 
-    // Enable ONLY the events we need to kickstart our initialization and rendering
     enable_event(METH_DXGI_CreateSwapChain, WRAP_CB_POST);
     enable_event(METH_SWC_Present, WRAP_CB_PRE);
     enable_event(METH_SWC_ResizeBuffers, WRAP_CB_POST);
 
-    // Watch for the swap chain creation event. This is our main initialization point.
+    // Watch for swap chain creation. This is our main initialization point.
+    // We DO NOT unwatch this event, so we can re-initialize if needed.
     g_al_api->watch_event(
         g_al_api->query_event(g_al_api->hash_name(L"D3D9_POST_DXGI_CreateSwapChain")),
         g_al_api->hash_name(L"kxvision_init"),
-        [](void* data) { // Lambda function for our callback
-            D3D9_wrapper_event_data* evd = (D3D9_wrapper_event_data*)data;
-            dxgi_CreateSwapChain_cp* params = (dxgi_CreateSwapChain_cp*)evd->stackPtr;
-
-            // This is the FIRST point where we have a D3D device. Initialize our renderer.
-            if (kx::Hooking::D3DRenderHook::InitializeFromDevice(
-                (ID3D11Device*)params->inDevice,
-                *params->ppSwapchain
-            )) {
-                LOG_INFO("D3DRenderHook initialized successfully from GW2AL");
-                
-                // Notify the lifecycle manager that the renderer is ready
-                kx::g_App.OnRendererInitialized();
-                
-                // Now that the renderer is initialized, we can unwatch this event.
-                g_al_api->unwatch_event(
-                    g_al_api->query_event(g_al_api->hash_name(L"D3D9_POST_DXGI_CreateSwapChain")), 
-                    g_al_api->hash_name(L"kxvision_init")
-                );
-            } else {
-                LOG_ERROR("Failed to initialize D3DRenderHook from GW2AL");
-            }
-        },
-        -1 // High priority to initialize as early as possible
+        (gw2al_api_event_handler)&OnDXGIPostCreateSwapChain,
+        -1 // High priority
     );
 
     // Watch for the Present call every frame. This is our render loop.
@@ -199,7 +218,7 @@ extern "C" __declspec(dllexport) gw2al_api_ret gw2addon_load(gw2al_core_vtable* 
         g_al_api->query_event(g_al_api->hash_name(L"D3D9_PRE_SWC_Present")),
         g_al_api->hash_name(L"kxvision_present"),
         (gw2al_api_event_handler)&OnPresent,
-        0
+        10
     );
 
     // Watch for the ResizeBuffers event to handle window size changes.
@@ -207,7 +226,7 @@ extern "C" __declspec(dllexport) gw2al_api_ret gw2addon_load(gw2al_core_vtable* 
         g_al_api->query_event(g_al_api->hash_name(L"D3D9_POST_SWC_ResizeBuffers")),
         g_al_api->hash_name(L"kxvision_resize"),
         (gw2al_api_event_handler)&OnResize,
-        0
+        10
     );
 
     LOG_INFO("KXVision GW2AL event handlers registered successfully");

--- a/src/Hooking/D3DRenderHook_GW2AL.cpp
+++ b/src/Hooking/D3DRenderHook_GW2AL.cpp
@@ -1,11 +1,11 @@
 /**
  * @file D3DRenderHook_GW2AL.cpp
  * @brief GW2AL addon mode specific functionality
- * 
+ *
  * This file contains GW2AL-mode specific code:
  * - Simple WndProc that relies on GW2AL's input routing
  * - No Present hook (GW2AL provides the device directly)
- * 
+ *
  * This file is only compiled when GW2AL_BUILD is defined.
  */
 
@@ -17,19 +17,19 @@
 #include "../Core/AppState.h"
 #include "../../libs/ImGui/imgui.h"
 
-// Declare the external ImGui Win32 handler
+ // Declare the external ImGui Win32 handler
 extern LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 namespace kx::Hooking {
 
     LRESULT __stdcall D3DRenderHook::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-        // Simple WndProc for GW2AL mode - just handle ImGui input
-        // GW2AL loader manages input routing and game/addon separation
+        // Give ImGui first chance at input only when our window is open
         if (m_isInit && kx::AppState::Get().IsVisionWindowOpen()) {
             if (ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam)) {
                 ImGuiIO& io = ImGui::GetIO();
-                // Block input to game if ImGui wants it
-                if (io.WantCaptureMouse || io.WantCaptureKeyboard) {
+                // Only block input when ImGui explicitly needs it
+                if ((io.WantCaptureMouse && (uMsg >= WM_MOUSEFIRST && uMsg <= WM_MOUSELAST)) ||
+                    (io.WantCaptureKeyboard && (uMsg >= WM_KEYFIRST && uMsg <= WM_KEYLAST))) {
                     return 1;
                 }
             }

--- a/src/Hooking/D3DRenderHook_Shared.cpp
+++ b/src/Hooking/D3DRenderHook_Shared.cpp
@@ -1,7 +1,7 @@
 /**
  * @file D3DRenderHook_Shared.cpp
  * @brief Shared D3D11 rendering functionality used by both DLL and GW2AL modes
- * 
+ *
  * This file contains code that is common to both build modes:
  * - Device initialization from swap chain (GW2AL mode)
  * - Resize event handling
@@ -34,45 +34,80 @@ namespace kx::Hooking {
 
         LOG_INFO("[D3DRenderHook] Initializing from provided device (GW2AL mode)");
 
-        m_pDevice = device;
-        m_pDevice->AddRef(); // Must AddRef since we Release in Shutdown()
-        m_pDevice->GetImmediateContext(&m_pContext);
+        // 1. Check for null pointers immediately to prevent crashes.
+        if (!device || !pSwapChain) {
+            LOG_ERROR("[D3DRenderHook] Null device or swap chain provided during initialization");
+            return false;
+        }
 
-        // Get window handle from swap chain
-        DXGI_SWAP_CHAIN_DESC sd;
-        pSwapChain->GetDesc(&sd);
-        m_hWindow = sd.OutputWindow;
+        // 2. Use a try-catch block as a safety net against any unexpected C++ exceptions.
+        try {
+            m_pDevice = device;
+            // 3. CRITICAL: We must increment the reference count because we are storing our own
+            // copy of the device pointer. Our Shutdown() function will call Release().
+            m_pDevice->AddRef();
 
-        // Create the render target view
-        ID3D11Texture2D* pBackBuffer = nullptr;
-        if (SUCCEEDED(pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBuffer))) {
-            m_pDevice->CreateRenderTargetView(pBackBuffer, NULL, &m_pMainRenderTargetView);
+            m_pDevice->GetImmediateContext(&m_pContext);
+
+            // Get window handle from swap chain description
+            DXGI_SWAP_CHAIN_DESC sd;
+            HRESULT hr = pSwapChain->GetDesc(&sd);
+            if (FAILED(hr)) {
+                LOG_ERROR("[D3DRenderHook] Failed to get swap chain description. HRESULT: 0x%08X", hr);
+                // No resources to clean up yet, just return.
+                return false;
+            }
+            m_hWindow = sd.OutputWindow;
+
+            // Create the render target view (RTV) for rendering our UI
+            ID3D11Texture2D* pBackBuffer = nullptr;
+            hr = pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBuffer);
+            if (FAILED(hr) || !pBackBuffer) {
+                LOG_ERROR("[D3DRenderHook] Failed to get back buffer from swap chain. HRESULT: 0x%08X", hr);
+                if (pBackBuffer) pBackBuffer->Release();
+                return false;
+            }
+
+            hr = m_pDevice->CreateRenderTargetView(pBackBuffer, NULL, &m_pMainRenderTargetView);
+            // 4. IMPORTANT: Release the back buffer immediately after creating the RTV from it.
             pBackBuffer->Release();
-        } else {
-            LOG_ERROR("[D3DRenderHook] Failed to get back buffer from GW2AL swap chain.");
+
+            if (FAILED(hr) || !m_pMainRenderTargetView) {
+                LOG_ERROR("[D3DRenderHook] Failed to create render target view. HRESULT: 0x%08X", hr);
+                return false;
+            }
+
+            // Hook the window procedure to handle input for our UI
+            m_pOriginalWndProc = (WNDPROC)SetWindowLongPtr(m_hWindow, GWLP_WNDPROC, (LONG_PTR)WndProc);
+            if (!m_pOriginalWndProc) {
+                LOG_ERROR("[D3DRenderHook] Failed to hook WndProc in GW2AL mode.");
+                // 5. Cleanup: If this step fails, release the RTV we just created.
+                if (m_pMainRenderTargetView) { m_pMainRenderTargetView->Release(); m_pMainRenderTargetView = nullptr; }
+                return false;
+            }
+
+            // Initialize ImGui
+            if (!ImGuiManager::Initialize(m_pDevice, m_pContext, m_hWindow)) {
+                LOG_ERROR("[D3DRenderHook] Failed to initialize ImGui in GW2AL mode.");
+                // 6. Cleanup: If ImGui fails, we must restore the original WndProc and release the RTV.
+                SetWindowLongPtr(m_hWindow, GWLP_WNDPROC, (LONG_PTR)m_pOriginalWndProc);
+                if (m_pMainRenderTargetView) { m_pMainRenderTargetView->Release(); m_pMainRenderTargetView = nullptr; }
+                return false;
+            }
+
+            m_isInit = true;
+            LOG_INFO("[D3DRenderHook] Initialized successfully via GW2AL.");
+            kx::AppState::Get().SetPresentHookStatus(kx::HookStatus::OK);
+            return true;
+        }
+        catch (const std::exception& e) {
+            LOG_ERROR("[D3DRenderHook] Exception during D3D initialization: %s", e.what());
             return false;
         }
-
-        // Hook WndProc (still needed for input handling)
-        m_pOriginalWndProc = (WNDPROC)SetWindowLongPtr(m_hWindow, GWLP_WNDPROC, (LONG_PTR)WndProc);
-        if (!m_pOriginalWndProc) {
-            LOG_ERROR("[D3DRenderHook] Failed to hook WndProc in GW2AL mode.");
-            if (m_pMainRenderTargetView) { m_pMainRenderTargetView->Release(); m_pMainRenderTargetView = nullptr; }
+        catch (...) {
+            LOG_ERROR("[D3DRenderHook] Unknown exception during D3D initialization.");
             return false;
         }
-
-        // Initialize ImGui
-        if (!ImGuiManager::Initialize(m_pDevice, m_pContext, m_hWindow)) {
-            LOG_ERROR("[D3DRenderHook] Failed to initialize ImGui in GW2AL mode.");
-            SetWindowLongPtr(m_hWindow, GWLP_WNDPROC, (LONG_PTR)m_pOriginalWndProc); // Restore WndProc
-            if (m_pMainRenderTargetView) { m_pMainRenderTargetView->Release(); m_pMainRenderTargetView = nullptr; }
-            return false;
-        }
-
-        m_isInit = true;
-        LOG_INFO("[D3DRenderHook] Initialized successfully via GW2AL.");
-        kx::AppState::Get().SetPresentHookStatus(kx::HookStatus::OK);
-        return true;
     }
 
     void D3DRenderHook::OnResize(IDXGISwapChain* pSwapChain) {

--- a/src/Hooking/D3DRenderHook_Shared.cpp
+++ b/src/Hooking/D3DRenderHook_Shared.cpp
@@ -64,7 +64,6 @@ namespace kx::Hooking {
             hr = pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBuffer);
             if (FAILED(hr) || !pBackBuffer) {
                 LOG_ERROR("[D3DRenderHook] Failed to get back buffer from swap chain. HRESULT: 0x%08X", hr);
-                if (pBackBuffer) pBackBuffer->Release();
                 return false;
             }
 

--- a/src/Hooking/GW2AL/d3d9_wrapper_structs.h
+++ b/src/Hooking/GW2AL/d3d9_wrapper_structs.h
@@ -2,42 +2,54 @@
 
 #include <d3d11.h>
 #include <dxgi.h>
+#include <dxgi1_2.h> // For DXGI_SWAP_CHAIN_DESC1, etc.
 
 /**
  * @file d3d9_wrapper_structs.h
  * @brief Structure definitions for GW2AL d3d9_wrapper event callbacks
- * 
- * These structures define the stack parameters passed to event callbacks
- * by the GW2AL d3d9_wrapper addon.
  */
 
-/**
- * @brief Parameters for DXGI CreateSwapChain call
- */
-struct dxgi_CreateSwapChain_cp {
-    IDXGIFactory* factory;
+ // These are the structs that the d3d9_wrapper expects in stackPtr
+
+typedef struct com_vtable {
+    void* methods[1024];
+} com_vtable;
+
+typedef struct com_orig_obj {
+    com_vtable* vtable;
+    void* original_obj; // Points to the original COM object
+} com_orig_obj;
+
+typedef struct wrapped_com_obj {
+    com_orig_obj* orig_obj; // Points to the original COM object wrapper
+    union {
+        ID3D11Device* orig_dev11;
+        IDXGISwapChain* orig_swc;
+        IDXGIFactory* orig_dxgi;
+    };
+} wrapped_com_obj;
+
+// CreateSwapChain params structure
+typedef struct dxgi_CreateSwapChain_cp {
+    IDXGIFactory* dxgi;
     IUnknown* inDevice;
-    DXGI_SWAP_CHAIN_DESC* pDesc;
+    DXGI_SWAP_CHAIN_DESC* desc;
     IDXGISwapChain** ppSwapchain;
-};
+} dxgi_CreateSwapChain_cp;
 
-/**
- * @brief Parameters for IDXGISwapChain::Present call
- */
-struct swc_Present_cp {
+// Present params structure
+typedef struct swc_Present_cp {
     IDXGISwapChain* swc;
     UINT SyncInterval;
     UINT Flags;
-};
+} swc_Present_cp;
 
-/**
- * @brief Parameters for IDXGISwapChain::ResizeBuffers call
- */
-struct swc_ResizeBuffers_cp {
+// ResizeBuffers params structure
+typedef struct swc_ResizeBuffers_cp {
     IDXGISwapChain* swc;
     UINT BufferCount;
     UINT Width;
     UINT Height;
     DXGI_FORMAT NewFormat;
     UINT SwapChainFlags;
-};
+} swc_ResizeBuffers_cp;

--- a/src/Rendering/D3DState.h
+++ b/src/Rendering/D3DState.h
@@ -5,125 +5,138 @@
 
 #include <d3d11.h>
 #include <windows.h>
+#include <mutex>
 
 namespace kx {
 
-/**
- * @brief Structure to hold D3D11 state for backup/restore operations
- * 
- * This is essential in GW2AL mode where we share the rendering pipeline
- * with the game and other addons. We must save and restore all state.
- * 
- * Optimized version: Only backs up state that ImGui actually modifies,
- * plus depth/stencil and render targets for maximum addon compatibility.
- * 
- * Size: ~300 bytes (vs ~3KB for full pipeline backup)
- */
-struct StateBackupD3D11 {
-    // Viewport and scissor
-    UINT ScissorRectsCount = 0;
-    UINT ViewportsCount = 0;
-    D3D11_RECT ScissorRects[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
-    D3D11_VIEWPORT Viewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
-    
-    // Rasterizer state
-    ID3D11RasterizerState* RS = nullptr;
-    
-    // Blend state
-    ID3D11BlendState* BlendState = nullptr;
-    FLOAT BlendFactor[4] = {};
-    UINT SampleMask = 0;
-    
-    // Depth/stencil state (for addon compatibility)
-    ID3D11DepthStencilState* DepthStencilState = nullptr;
-    UINT StencilRef = 0;
-    
-    // Output Merger render targets and depth-stencil view
-    // CRITICAL: ImGui rendering binds its own render target, so we must backup and restore
-    // the game's render targets to prevent breaking rendering
-    ID3D11RenderTargetView* RenderTargetViews[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
-    ID3D11DepthStencilView* DepthStencilView = nullptr;
-    
-    // Shaders (ImGui uses VS and PS only)
-    ID3D11PixelShader* PS = nullptr;
-    ID3D11VertexShader* VS = nullptr;
-    
-    // Input assembly
-    D3D11_PRIMITIVE_TOPOLOGY PrimitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
-    ID3D11Buffer* IndexBuffer = nullptr;
-    ID3D11Buffer* VertexBuffer = nullptr;
-    ID3D11Buffer* VSConstantBuffer = nullptr;
-    UINT IndexBufferOffset = 0;
-    UINT VertexBufferStride = 0;
-    UINT VertexBufferOffset = 0;
-    DXGI_FORMAT IndexBufferFormat = DXGI_FORMAT_UNKNOWN;
-    ID3D11InputLayout* InputLayout = nullptr;
-    
-    // Texture and sampler (slot 0 only, ImGui uses 1 texture)
-    ID3D11ShaderResourceView* PSShaderResource = nullptr;
-    ID3D11SamplerState* PSSampler = nullptr;
-};
+    inline std::mutex g_d3dStateMutex;
 
-/**
- * @brief Backup D3D11 state from the device context
- * 
- * Backs up all state that ImGui modifies, including render targets and depth-stencil view.
- * This is critical for compatibility with the game and other overlays - ImGui binds its own
- * render target, so we must backup and restore the game's render targets.
- * 
- * Performance: ~20-25 microseconds per backup/restore cycle
- */
-inline void BackupD3D11State(ID3D11DeviceContext* ctx, StateBackupD3D11& backup) {
-    backup.ScissorRectsCount = backup.ViewportsCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
-    ctx->RSGetScissorRects(&backup.ScissorRectsCount, backup.ScissorRects);
-    ctx->RSGetViewports(&backup.ViewportsCount, backup.Viewports);
-    ctx->RSGetState(&backup.RS);
-    ctx->OMGetBlendState(&backup.BlendState, backup.BlendFactor, &backup.SampleMask);
-    ctx->OMGetDepthStencilState(&backup.DepthStencilState, &backup.StencilRef);
-    ctx->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, backup.RenderTargetViews, &backup.DepthStencilView);
-    ctx->PSGetShaderResources(0, 1, &backup.PSShaderResource);
-    ctx->PSGetSamplers(0, 1, &backup.PSSampler);
-    ctx->PSGetShader(&backup.PS, nullptr, nullptr);
-    ctx->VSGetShader(&backup.VS, nullptr, nullptr);
-    ctx->VSGetConstantBuffers(0, 1, &backup.VSConstantBuffer);
-    ctx->IAGetPrimitiveTopology(&backup.PrimitiveTopology);
-    ctx->IAGetIndexBuffer(&backup.IndexBuffer, &backup.IndexBufferFormat, &backup.IndexBufferOffset);
-    ctx->IAGetVertexBuffers(0, 1, &backup.VertexBuffer, &backup.VertexBufferStride, &backup.VertexBufferOffset);
-    ctx->IAGetInputLayout(&backup.InputLayout);
-}
+    /**
+     * @brief Structure to hold D3D11 state for backup/restore operations
+     *
+     * This is essential in GW2AL mode where we share the rendering pipeline
+     * with the game and other addons. We must save and restore all state.
+     *
+     * Optimized version: Only backs up state that ImGui actually modifies,
+     * plus depth/stencil and render targets for maximum addon compatibility.
+     *
+     * Size: ~300 bytes (vs ~3KB for full pipeline backup)
+     */
+    struct StateBackupD3D11 {
+        // Viewport and scissor
+        UINT ScissorRectsCount = 0;
+        UINT ViewportsCount = 0;
+        D3D11_RECT ScissorRects[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
+        D3D11_VIEWPORT Viewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE] = {};
 
-/**
- * @brief Restore D3D11 state to the device context
- * 
- * Restores the state that was backed up by BackupD3D11State().
- * Properly releases all COM references to avoid memory leaks.
- * 
- * CRITICAL: Restores render targets and depth-stencil view to prevent breaking
- * game rendering or other overlays.
- */
-inline void RestoreD3D11State(ID3D11DeviceContext* ctx, StateBackupD3D11& backup) {
-    ctx->RSSetScissorRects(backup.ScissorRectsCount, backup.ScissorRects);
-    ctx->RSSetViewports(backup.ViewportsCount, backup.Viewports);
-    ctx->RSSetState(backup.RS); if (backup.RS) backup.RS->Release();
-    ctx->OMSetBlendState(backup.BlendState, backup.BlendFactor, backup.SampleMask); if (backup.BlendState) backup.BlendState->Release();
-    ctx->OMSetDepthStencilState(backup.DepthStencilState, backup.StencilRef); if (backup.DepthStencilState) backup.DepthStencilState->Release();
-    ctx->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, backup.RenderTargetViews, backup.DepthStencilView);
-    // Release all render target views
-    for (UINT i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++) {
-        if (backup.RenderTargetViews[i]) {
-            backup.RenderTargetViews[i]->Release();
-        }
+        // Rasterizer state
+        ID3D11RasterizerState* RS = nullptr;
+
+        // Blend state
+        ID3D11BlendState* BlendState = nullptr;
+        FLOAT BlendFactor[4] = {};
+        UINT SampleMask = 0;
+
+        // Depth/stencil state (for addon compatibility)
+        ID3D11DepthStencilState* DepthStencilState = nullptr;
+        UINT StencilRef = 0;
+
+        // Output Merger render targets and depth-stencil view
+        // CRITICAL: ImGui rendering binds its own render target, so we must backup and restore
+        // the game's render targets to prevent breaking rendering
+        ID3D11RenderTargetView* RenderTargetViews[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT] = {};
+        ID3D11DepthStencilView* DepthStencilView = nullptr;
+
+        // Shaders (ImGui uses VS and PS only)
+        ID3D11PixelShader* PS = nullptr;
+        ID3D11VertexShader* VS = nullptr;
+
+        // Input assembly
+        D3D11_PRIMITIVE_TOPOLOGY PrimitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_UNDEFINED;
+        ID3D11Buffer* IndexBuffer = nullptr;
+        ID3D11Buffer* VertexBuffer = nullptr;
+        ID3D11Buffer* VSConstantBuffer = nullptr;
+        UINT IndexBufferOffset = 0;
+        UINT VertexBufferStride = 0;
+        UINT VertexBufferOffset = 0;
+        DXGI_FORMAT IndexBufferFormat = DXGI_FORMAT_UNKNOWN;
+        ID3D11InputLayout* InputLayout = nullptr;
+
+        // Texture and sampler (slot 0 only, ImGui uses 1 texture)
+        ID3D11ShaderResourceView* PSShaderResource = nullptr;
+        ID3D11SamplerState* PSSampler = nullptr;
+    };
+
+    /**
+     * @brief Backup D3D11 state from the device context with mutex protection
+     *
+     * Backs up all state that ImGui modifies, including render targets and depth-stencil view.
+     * This is critical for compatibility with the game and other overlays - ImGui binds its own
+     * render target, so we must backup and restore the game's render targets.
+     *
+     * Performance: ~20-25 microseconds per backup/restore cycle
+     */
+    inline void BackupD3D11State(ID3D11DeviceContext* ctx, StateBackupD3D11& backup) {
+        std::lock_guard<std::mutex> lock(g_d3dStateMutex);
+
+        // Ensure context is valid
+        if (!ctx) return;
+
+        backup.ScissorRectsCount = backup.ViewportsCount = D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE;
+        ctx->RSGetScissorRects(&backup.ScissorRectsCount, backup.ScissorRects);
+        ctx->RSGetViewports(&backup.ViewportsCount, backup.Viewports);
+        ctx->RSGetState(&backup.RS);
+        ctx->OMGetBlendState(&backup.BlendState, backup.BlendFactor, &backup.SampleMask);
+        ctx->OMGetDepthStencilState(&backup.DepthStencilState, &backup.StencilRef);
+        ctx->OMGetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, backup.RenderTargetViews, &backup.DepthStencilView);
+        ctx->PSGetShaderResources(0, 1, &backup.PSShaderResource);
+        ctx->PSGetSamplers(0, 1, &backup.PSSampler);
+        ctx->PSGetShader(&backup.PS, nullptr, nullptr);
+        ctx->VSGetShader(&backup.VS, nullptr, nullptr);
+        ctx->VSGetConstantBuffers(0, 1, &backup.VSConstantBuffer);
+        ctx->IAGetPrimitiveTopology(&backup.PrimitiveTopology);
+        ctx->IAGetIndexBuffer(&backup.IndexBuffer, &backup.IndexBufferFormat, &backup.IndexBufferOffset);
+        ctx->IAGetVertexBuffers(0, 1, &backup.VertexBuffer, &backup.VertexBufferStride, &backup.VertexBufferOffset);
+        ctx->IAGetInputLayout(&backup.InputLayout);
     }
-    if (backup.DepthStencilView) backup.DepthStencilView->Release();
-    ctx->PSSetShaderResources(0, 1, &backup.PSShaderResource); if (backup.PSShaderResource) backup.PSShaderResource->Release();
-    ctx->PSSetSamplers(0, 1, &backup.PSSampler); if (backup.PSSampler) backup.PSSampler->Release();
-    ctx->PSSetShader(backup.PS, nullptr, 0); if (backup.PS) backup.PS->Release();
-    ctx->VSSetShader(backup.VS, nullptr, 0); if (backup.VS) backup.VS->Release();
-    ctx->VSSetConstantBuffers(0, 1, &backup.VSConstantBuffer); if (backup.VSConstantBuffer) backup.VSConstantBuffer->Release();
-    ctx->IASetPrimitiveTopology(backup.PrimitiveTopology);
-    ctx->IASetIndexBuffer(backup.IndexBuffer, backup.IndexBufferFormat, backup.IndexBufferOffset); if (backup.IndexBuffer) backup.IndexBuffer->Release();
-    ctx->IASetVertexBuffers(0, 1, &backup.VertexBuffer, &backup.VertexBufferStride, &backup.VertexBufferOffset); if (backup.VertexBuffer) backup.VertexBuffer->Release();
-    ctx->IASetInputLayout(backup.InputLayout); if (backup.InputLayout) backup.InputLayout->Release();
-}
+
+    /**
+     * @brief Restore D3D11 state to the device context with mutex protection
+     *
+     * Restores the state that was backed up by BackupD3D11State().
+     * Properly releases all COM references to avoid memory leaks.
+     *
+     * CRITICAL: Restores render targets and depth-stencil view to prevent breaking
+     * game rendering or other overlays.
+     */
+    inline void RestoreD3D11State(ID3D11DeviceContext* ctx, StateBackupD3D11& backup) {
+        std::lock_guard<std::mutex> lock(g_d3dStateMutex);
+
+        // Ensure context is valid
+        if (!ctx) return;
+
+        ctx->RSSetScissorRects(backup.ScissorRectsCount, backup.ScissorRects);
+        ctx->RSSetViewports(backup.ViewportsCount, backup.Viewports);
+        ctx->RSSetState(backup.RS); if (backup.RS) backup.RS->Release();
+        ctx->OMSetBlendState(backup.BlendState, backup.BlendFactor, backup.SampleMask); if (backup.BlendState) backup.BlendState->Release();
+        ctx->OMSetDepthStencilState(backup.DepthStencilState, backup.StencilRef); if (backup.DepthStencilState) backup.DepthStencilState->Release();
+        ctx->OMSetRenderTargets(D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT, backup.RenderTargetViews, backup.DepthStencilView);
+        // Release all render target views
+        for (UINT i = 0; i < D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT; i++) {
+            if (backup.RenderTargetViews[i]) {
+                backup.RenderTargetViews[i]->Release();
+            }
+        }
+        if (backup.DepthStencilView) backup.DepthStencilView->Release();
+        ctx->PSSetShaderResources(0, 1, &backup.PSShaderResource); if (backup.PSShaderResource) backup.PSShaderResource->Release();
+        ctx->PSSetSamplers(0, 1, &backup.PSSampler); if (backup.PSSampler) backup.PSSampler->Release();
+        ctx->PSSetShader(backup.PS, nullptr, 0); if (backup.PS) backup.PS->Release();
+        ctx->VSSetShader(backup.VS, nullptr, 0); if (backup.VS) backup.VS->Release();
+        ctx->VSSetConstantBuffers(0, 1, &backup.VSConstantBuffer); if (backup.VSConstantBuffer) backup.VSConstantBuffer->Release();
+        ctx->IASetPrimitiveTopology(backup.PrimitiveTopology);
+        ctx->IASetIndexBuffer(backup.IndexBuffer, backup.IndexBufferFormat, backup.IndexBufferOffset); if (backup.IndexBuffer) backup.IndexBuffer->Release();
+        ctx->IASetVertexBuffers(0, 1, &backup.VertexBuffer, &backup.VertexBufferStride, &backup.VertexBufferOffset); if (backup.VertexBuffer) backup.VertexBuffer->Release();
+        ctx->IASetInputLayout(backup.InputLayout); if (backup.InputLayout) backup.InputLayout->Release();
+    }
 
 } // namespace kx


### PR DESCRIPTION
This PR overhauls the GW2AL integration to fix critical stability issues, preventing crashes during renderer initialization and when changing in-game graphics settings.

**Key Fixes:**
*   **Renderer Re-initialization:** The addon now correctly re-initializes after the graphics device is reset (e.g., changing display mode) by properly handling the `CreateSwapChain` event.
*   **Memory Safety:** Correctly interprets `d3d9_wrapper` event structures to prevent memory corruption and access violation crashes.
*   **Robust Initialization:** Added comprehensive error checking and exception handling to ensure the addon fails gracefully instead of crashing the game.