### PR TITLE
feat: Implement Dynamic Combat-Aware Health Bars

### DIFF
--- a/KX-Vision.vcxproj
+++ b/KX-Vision.vcxproj
@@ -100,6 +100,7 @@
     <ClCompile Include="src\Game\AddressManager.cpp" />
     <ClCompile Include="src\Game\Camera.cpp" />
     <ClCompile Include="src\Game\MumbleLinkManager.cpp" />
+    <ClCompile Include="src\Rendering\Combat\CombatStateManager.cpp" />
     <ClCompile Include="src\Rendering\Core\ESPDataExtractor.cpp" />
     <ClCompile Include="src\Rendering\Core\ESPFilter.cpp" />
     <ClCompile Include="src\Rendering\Core\ESPRenderer.cpp" />
@@ -172,6 +173,8 @@
     <ClInclude Include="src\Game\ReClass\StatStructs.h" />
     <ClInclude Include="src\Hooking\D3DRenderHook.h" />
     <ClInclude Include="src\Hooking\GW2AL\d3d9_wrapper_structs.h" />
+    <ClInclude Include="src\Rendering\Combat\CombatState.h" />
+    <ClInclude Include="src\Rendering\Combat\CombatStateManager.h" />
     <ClInclude Include="src\Rendering\Core\ESPDataExtractor.h" />
     <ClInclude Include="src\Rendering\Core\ESPFilter.h" />
     <ClInclude Include="src\Rendering\Core\ESPRenderer.h" />

--- a/src/Rendering/Combat/CombatState.h
+++ b/src/Rendering/Combat/CombatState.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+
+namespace kx {
+    // Holds the dynamic combat information for a single entity
+    struct EntityCombatState {
+        float lastKnownHealth = 0.0f;
+        float lastDamageTaken = 0.0f;
+        uint64_t lastHitTimestamp = 0;  // Time of the last detected damage event
+        uint64_t lastHealTimestamp = 0; // Time of the last detected healing event
+        uint64_t lastSeenTimestamp = 0; // Time the entity was last seen in a frame
+    };
+}

--- a/src/Rendering/Combat/CombatState.h
+++ b/src/Rendering/Combat/CombatState.h
@@ -7,7 +7,12 @@ namespace kx {
         float lastKnownHealth = 0.0f;
         float lastDamageTaken = 0.0f;
         uint64_t lastHitTimestamp = 0;  // Time of the last detected damage event
-        uint64_t lastHealTimestamp = 0; // Time of the last detected healing event
+        
+        // --- NEW MEMBERS FOR HEALING ---
+        float healStartHealth = 0.0f;   // Health value before the heal started
+        uint64_t lastHealTimestamp = 0; // Timestamp of the last healing event
+        uint64_t lastHealFlashTimestamp = 0; // Timestamp for the FAST flash effect
+
         uint64_t lastSeenTimestamp = 0; // Time the entity was last seen in a frame
     };
 }

--- a/src/Rendering/Combat/CombatState.h
+++ b/src/Rendering/Combat/CombatState.h
@@ -12,6 +12,7 @@ namespace kx {
         float healStartHealth = 0.0f;   // Health value before the heal started
         uint64_t lastHealTimestamp = 0; // Timestamp of the last healing event
         uint64_t lastHealFlashTimestamp = 0; // Timestamp for the FAST flash effect
+        uint64_t deathTimestamp = 0; // Timestamp for when health first hit zero
 
         uint64_t lastSeenTimestamp = 0; // Time the entity was last seen in a frame
     };

--- a/src/Rendering/Combat/CombatStateManager.cpp
+++ b/src/Rendering/Combat/CombatStateManager.cpp
@@ -1,0 +1,54 @@
+#include "CombatStateManager.h"
+#include "../Utils/ESPConstants.h"
+#include <Windows.h>
+#include <algorithm>
+
+namespace kx {
+    void CombatStateManager::Update(const std::vector<RenderableEntity*>& entities) {
+        uint64_t now = GetTickCount64();
+
+        for (const auto* entity : entities) {
+            if (!entity || !entity->isValid) continue;
+
+            // Only track entities with health
+            if (entity->maxHealth <= 0.0f) continue;
+
+            const void* entityId = entity->address;
+            float currentHealth = entity->currentHealth;
+
+            auto& state = m_entityStates[entityId];
+
+            if (state.lastSeenTimestamp > 0) {
+                if (currentHealth < state.lastKnownHealth) {
+                    state.lastDamageTaken = state.lastKnownHealth - currentHealth;
+                    state.lastHitTimestamp = now;
+                } else if (currentHealth > state.lastKnownHealth) {
+                    state.lastHealTimestamp = now;
+                }
+            }
+            
+            state.lastKnownHealth = currentHealth;
+            state.lastSeenTimestamp = now;
+        }
+    }
+
+    const EntityCombatState* CombatStateManager::GetState(const void* entityId) const {
+        auto it = m_entityStates.find(entityId);
+        if (it != m_entityStates.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
+
+    void CombatStateManager::Cleanup() {
+        uint64_t now = GetTickCount64();
+
+        for (auto it = m_entityStates.begin(); it != m_entityStates.end(); ) {
+            if (now - it->second.lastSeenTimestamp > CombatEffects::STATE_CLEANUP_THRESHOLD_MS) {
+                it = m_entityStates.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+}

--- a/src/Rendering/Combat/CombatStateManager.cpp
+++ b/src/Rendering/Combat/CombatStateManager.cpp
@@ -20,13 +20,22 @@ namespace kx {
 
             if (state.lastSeenTimestamp > 0) {
                 if (currentHealth < state.lastKnownHealth) {
+                    // --- Damage Logic ---
                     state.lastDamageTaken = state.lastKnownHealth - currentHealth;
                     state.lastHitTimestamp = now;
-                } else if (currentHealth > state.lastKnownHealth) {
+                }
+                else if (currentHealth > state.lastKnownHealth) {
+                    // --- Healing Logic ---
+                    if (now - state.lastHealTimestamp > CombatEffects::HEAL_OVERLAY_DURATION_MS) {
+                        state.healStartHealth = state.lastKnownHealth;
+                    }
+                    // Always update the timestamp to extend/start the overlay's duration
                     state.lastHealTimestamp = now;
+                    state.lastHealFlashTimestamp = now; // <-- ADD THIS LINE to trigger the flash
                 }
             }
             
+            // Update the state for the next frame
             state.lastKnownHealth = currentHealth;
             state.lastSeenTimestamp = now;
         }

--- a/src/Rendering/Combat/CombatStateManager.cpp
+++ b/src/Rendering/Combat/CombatStateManager.cpp
@@ -19,6 +19,17 @@ namespace kx {
         auto& state = m_entityStates[entityId];
 
         if (state.lastSeenTimestamp > 0) {
+            // --- NEW: DEATH DETECTION LOGIC ---
+            // Check if the entity just died THIS frame.
+            if (currentHealth <= 0.0f && state.lastKnownHealth > 0.0f) {
+                state.deathTimestamp = now;
+            }
+            // If the entity is alive, make sure the death timestamp is cleared
+            // (in case they resurrect).
+            else if (currentHealth > 0.0f) {
+                state.deathTimestamp = 0;
+            }
+
             if (currentHealth < state.lastKnownHealth) {
                 // --- Damage Logic ---
                 state.lastDamageTaken = state.lastKnownHealth - currentHealth;

--- a/src/Rendering/Combat/CombatStateManager.h
+++ b/src/Rendering/Combat/CombatStateManager.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include "CombatState.h"
+#include "../Data/RenderableData.h" // For RenderableEntity
+
+namespace kx {
+    class CombatStateManager {
+    public:
+        void Update(const std::vector<RenderableEntity*>& entities);
+        void Cleanup();
+        const EntityCombatState* GetState(const void* entityId) const;
+
+    private:
+        std::unordered_map<const void*, EntityCombatState> m_entityStates;
+    };
+}

--- a/src/Rendering/Core/ESPFilter.cpp
+++ b/src/Rendering/Core/ESPFilter.cpp
@@ -86,7 +86,7 @@ void ESPFilter::FilterPooledData(const PooledFrameRenderData& extractedData, Cam
                 const EntityCombatState* state = stateManager.GetState(npc->address);
                 if (state && state->deathTimestamp > 0) {
                     uint64_t timeSinceDeath = GetTickCount64() - state->deathTimestamp;
-                    if (timeSinceDeath < (CombatEffects::DEATH_EMBER_FADE_DURATION_MS + CombatEffects::DEATH_FINAL_FADE_DURATION_MS)) {
+                    if (timeSinceDeath < (CombatEffects::DEATH_BURST_DURATION_MS + CombatEffects::DEATH_FINAL_FADE_DURATION_MS)) {
                         // This is a fresh corpse, keep it for the animation.
                     } else {
                         continue; // Animation is over, filter it out.

--- a/src/Rendering/Core/ESPFilter.h
+++ b/src/Rendering/Core/ESPFilter.h
@@ -5,6 +5,8 @@
 
 namespace kx {
 
+class CombatStateManager; // Forward declaration
+
 /**
  * @brief Filtering stage for the ESP rendering pipeline
  * 
@@ -28,9 +30,10 @@ public:
      * @param extractedData Input pooled data from extraction
      * @param camera Camera for distance calculations
      * @param filteredData Output filtered pooled data
+     * @param stateManager The combat state manager for state-aware filtering
      */
     static void FilterPooledData(const PooledFrameRenderData& extractedData, Camera& camera,
-                                PooledFrameRenderData& filteredData);
+                                PooledFrameRenderData& filteredData, const CombatStateManager& stateManager);
 
 private:
     /**

--- a/src/Rendering/Core/ESPRenderer.cpp
+++ b/src/Rendering/Core/ESPRenderer.cpp
@@ -72,7 +72,7 @@ void ESPRenderer::Render(float screenWidth, float screenHeight, const MumbleLink
         g_combatStateManager.Update(allEntities);
         
         // Stage 2: Filter the pooled data (safe, configurable operations)  
-        ESPFilter::FilterPooledData(extractedData, *s_camera, s_cachedFilteredData);
+        ESPFilter::FilterPooledData(extractedData, *s_camera, s_cachedFilteredData, g_combatStateManager);
         
         // Stage 2.5: Update adaptive far plane for "No Limit" mode (once per second internally)
         AppState::Get().UpdateAdaptiveFarPlane(s_cachedFilteredData);

--- a/src/Rendering/Core/ESPStageRenderer.h
+++ b/src/Rendering/Core/ESPStageRenderer.h
@@ -12,6 +12,7 @@ namespace kx {
 
 // Forward declaration for context struct
 struct EntityRenderContext;
+class CombatStateManager;
 
 /**
  * @brief Handles safe rendering from extracted data (Stage 2 of rendering pipeline)
@@ -32,25 +33,31 @@ public:
      * @param screenHeight Screen height in pixels
      * @param frameData Pooled extracted data for this frame (contains pointers)
      * @param camera Camera reference for world-to-screen calculations
+     * @param stateManager Reference to the combat state manager
      */
     static void RenderFrameData(ImDrawList* drawList, float screenWidth, float screenHeight, 
-                               const PooledFrameRenderData& frameData, Camera& camera);
+                               const PooledFrameRenderData& frameData, Camera& camera, 
+                               const CombatStateManager& stateManager);
 
 private:
     // Pooled rendering functions for optimized performance
     static void RenderPooledPlayers(ImDrawList* drawList, float screenWidth, float screenHeight, 
-                                   const std::vector<RenderablePlayer*>& players, Camera& camera);
+                                   const std::vector<RenderablePlayer*>& players, Camera& camera, 
+                                   const CombatStateManager& stateManager);
 
     static void RenderPooledNpcs(ImDrawList* drawList, float screenWidth, float screenHeight, 
-                                const std::vector<RenderableNpc*>& npcs, Camera& camera);
+                                const std::vector<RenderableNpc*>& npcs, Camera& camera, 
+                                const CombatStateManager& stateManager);
 
     static void RenderPooledGadgets(ImDrawList* drawList, float screenWidth, float screenHeight, 
-                                   const std::vector<RenderableGadget*>& gadgets, Camera& camera);
+                                   const std::vector<RenderableGadget*>& gadgets, Camera& camera, 
+                                   const CombatStateManager& stateManager);
 
     /**
      * @brief Universal entity rendering function using context struct
      */
-    static void RenderEntity(ImDrawList* drawList, const EntityRenderContext& context, Camera& camera);
+    static void RenderEntity(ImDrawList* drawList, const EntityRenderContext& context, Camera& camera, 
+                           const CombatStateManager& stateManager);
 
     /**
      * @brief Render all visual components for an entity
@@ -70,13 +77,15 @@ private:
      * @param finalDotRadius Final scaled dot radius
      * @param finalHealthBarWidth Final scaled health bar width
      * @param finalHealthBarHeight Final scaled health bar height
+     * @param stateManager Reference to the combat state manager
      */
     static void RenderEntityComponents(ImDrawList* drawList, const EntityRenderContext& context,
                                       const glm::vec2& screenPos, const ImVec2& boxMin, const ImVec2& boxMax,
                                       const ImVec2& center, unsigned int fadedEntityColor, 
                                       float distanceFadeAlpha, float scale, float circleRadius,
                                       float finalAlpha, float finalFontSize, float finalBoxThickness,
-                                      float finalDotRadius, float finalHealthBarWidth, float finalHealthBarHeight);
+                                      float finalDotRadius, float finalHealthBarWidth, float finalHealthBarHeight,
+                                      const CombatStateManager& stateManager);
 
     // Distance fading helper function
     static float CalculateEntityDistanceFadeAlpha(float distance, bool useDistanceLimit, float distanceLimit);

--- a/src/Rendering/Data/EntityRenderContext.h
+++ b/src/Rendering/Data/EntityRenderContext.h
@@ -89,8 +89,11 @@ struct EntityRenderContext {
     /** Screen height for bounds checking */
     float screenHeight;
     
-    // ===== Player-Specific Data =====
+    // ===== Entity-Specific Data =====
     
+    /** Pointer to the original entity for state lookup */
+    const RenderableEntity* entity;
+
     /** Player name (empty string for non-players) */
     const std::string& playerName;
     

--- a/src/Rendering/Renderers/ESPContextFactory.cpp
+++ b/src/Rendering/Renderers/ESPContextFactory.cpp
@@ -65,6 +65,7 @@ EntityRenderContext ESPContextFactory::CreateContextForPlayer(const RenderablePl
         Game::CharacterRank::Ambient, // Players are considered Ambient for rank purposes
         screenWidth,
         screenHeight,
+        player, // entity pointer
         player->playerName,
         player
     };
@@ -118,6 +119,7 @@ EntityRenderContext ESPContextFactory::CreateContextForNpc(const RenderableNpc* 
         npc->rank,
         screenWidth,
         screenHeight,
+        npc, // entity pointer
         emptyPlayerName,
         nullptr
     };
@@ -149,6 +151,7 @@ EntityRenderContext ESPContextFactory::CreateContextForGadget(const RenderableGa
         Game::CharacterRank::Normal, // Gadgets don't have ranks
         screenWidth,
         screenHeight,
+        gadget, // entity pointer
         emptyPlayerName,
         nullptr
     };

--- a/src/Rendering/Renderers/ESPHealthBarRenderer.cpp
+++ b/src/Rendering/Renderers/ESPHealthBarRenderer.cpp
@@ -1,14 +1,19 @@
 #include "ESPHealthBarRenderer.h"
 #include "../Utils/ESPConstants.h"
 #include "../../../libs/ImGui/imgui.h"
+#include <Windows.h>
+#include "../Combat/CombatStateManager.h"
+#include "../Data/EntityRenderContext.h"
+#include <algorithm>
+#include <cmath>
 
 namespace kx {
 
 void ESPHealthBarRenderer::RenderStandaloneHealthBar(ImDrawList* drawList, const glm::vec2& centerPos,
-                                                     float healthPercent, unsigned int entityColor,
+                                                     const EntityRenderContext& context, unsigned int entityColor,
                                                      float barWidth, float barHeight,
-                                                     ESPEntityType entityType, Game::Attitude attitude) {
-    if (healthPercent < 0.0f || healthPercent > 1.0f) return;
+                                                     const CombatStateManager& stateManager) {
+    if (context.healthPercent < 0.0f || context.healthPercent > 1.0f) return;
 
     // Extract alpha from entity color for distance fading
     float fadeAlpha = ((entityColor >> 24) & 0xFF) / 255.0f;
@@ -25,7 +30,7 @@ void ESPHealthBarRenderer::RenderStandaloneHealthBar(ImDrawList* drawList, const
     drawList->AddRectFilled(barMin, barMax, IM_COL32(0, 0, 0, bgAlpha), RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
 
     // Health fill dimensions
-    float healthWidth = barWidth * healthPercent;
+    float healthWidth = barWidth * context.healthPercent;
     ImVec2 healthBarMin(barMin.x, barMin.y);
     ImVec2 healthBarMax(barMin.x + healthWidth, barMax.y);
 
@@ -37,12 +42,60 @@ void ESPHealthBarRenderer::RenderStandaloneHealthBar(ImDrawList* drawList, const
     
     // Replace alpha component with health bar alpha, keep RGB unchanged
     unsigned int healthColor = (entityColor & 0x00FFFFFF) | (healthAlpha << 24);
+
+    // --- NEW HEALING PULSE LOGIC ---
+    const RenderableEntity* entity = context.entity;
+    if (!entity) return; // Should not happen if health bar is drawn
+    const EntityCombatState* state = stateManager.GetState(entity->address);
+    if (state && state->lastHealTimestamp > 0) {
+        uint64_t timeSinceHeal = GetTickCount64() - state->lastHealTimestamp;
+
+        if (timeSinceHeal < CombatEffects::HEAL_PULSE_DURATION_MS) {
+            // Use a sine wave that completes one full pulse over the duration
+            float pulseProgress = (float)timeSinceHeal / CombatEffects::HEAL_PULSE_DURATION_MS;
+            float pulse = sin(pulseProgress * 3.14159f); // A single hump from 0 -> 1 -> 0
+
+            // Interpolate the health bar color towards a bright, vibrant green
+            int r = (healthColor >> 0) & 0xFF;
+            int g = (healthColor >> 8) & 0xFF;
+            int b = (healthColor >> 16) & 0xFF;
+            int a = (healthColor >> 24) & 0xFF;
+
+            r -= (int)(r * pulse * 0.8f); // Pull red down
+            g = g + (int)((255 - g) * pulse); // Push green to max
+            b -= (int)(b * pulse * 0.8f); // Pull blue down
+
+            healthColor = IM_COL32(r, g, b, a);
+        }
+    }
     
     // Draw health fill
     drawList->AddRectFilled(healthBarMin, healthBarMax, healthColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
 
+    // --- ENHANCED DAMAGE FLASH LOGIC ---
+    if (state && state->lastHitTimestamp > 0) {
+        uint64_t timeSinceHit = GetTickCount64() - state->lastHitTimestamp;
+
+        if (timeSinceHit < CombatEffects::DAMAGE_FLASH_DURATION_MS) {
+            float fadeProgress = (float)timeSinceHit / CombatEffects::DAMAGE_FLASH_DURATION_MS;
+            float flashAlpha = 1.0f - (fadeProgress * fadeProgress);
+
+            ImU32 flashColor = IM_COL32(255, 255, 0, (int)(flashAlpha * 255));
+
+            float currentHealthPercent = entity->currentHealth / entity->maxHealth;
+            float previousHealthPercent = (entity->currentHealth + state->lastDamageTaken) / entity->maxHealth;
+
+            ImVec2 flashMin = ImVec2(barMin.x + barWidth * currentHealthPercent, barMin.y);
+            ImVec2 flashMax = ImVec2(barMin.x + barWidth * (std::min)(1.0f, previousHealthPercent), barMax.y);
+
+            if (flashMin.x < flashMax.x) {
+                drawList->AddRectFilled(flashMin, flashMax, flashColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
+            }
+        }
+    }
+
     // Border for hostile entities - simple black border
-    if (attitude == Game::Attitude::Hostile) {
+    if (context.attitude == Game::Attitude::Hostile) {
         float borderAlphaf = RenderingLayout::STANDALONE_HEALTH_BAR_BORDER_ALPHA * fadeAlpha;
         unsigned int borderAlpha = static_cast<unsigned int>(borderAlphaf + 0.5f);
         borderAlpha = (borderAlpha > 255) ? 255 : borderAlpha;

--- a/src/Rendering/Renderers/ESPHealthBarRenderer.cpp
+++ b/src/Rendering/Renderers/ESPHealthBarRenderer.cpp
@@ -15,134 +15,132 @@ void ESPHealthBarRenderer::RenderStandaloneHealthBar(ImDrawList* drawList, const
                                                      const CombatStateManager& stateManager) {
     if (context.healthPercent < -1.0f) return; // Allow 0 health for dead entities
 
-    // --- Initial Setup ---
-    float fadeAlpha = ((entityColor >> 24) & 0xFF) / 255.0f;
-    float timeFade = 1.0f;
-
+    // --- 1. Initial Setup (The Controller's Job) ---
     const RenderableEntity* entity = context.entity;
     const EntityCombatState* state = stateManager.GetState(entity ? entity->address : nullptr);
     uint64_t now = GetTickCount64();
+    float fadeAlpha = ((entityColor >> 24) & 0xFF) / 255.0f;
+    float timeFade = 1.0f;
 
-    // --- CHECK IF ENTITY IS DEAD and handle final fade-out ---
+    // --- 2. Handle Final Fade-out After Death ---
     if (state && state->deathTimestamp > 0) {
         uint64_t timeSinceDeath = now - state->deathTimestamp;
-        
-        // Check if we are in the final fade-out period after the burst
         if (timeSinceDeath > CombatEffects::DEATH_BURST_DURATION_MS) {
             uint64_t timeIntoFade = timeSinceDeath - CombatEffects::DEATH_BURST_DURATION_MS;
             if (timeIntoFade < CombatEffects::DEATH_FINAL_FADE_DURATION_MS) {
-                float fadeProgress = (float)timeIntoFade / CombatEffects::DEATH_FINAL_FADE_DURATION_MS;
-                timeFade = 1.0f - fadeProgress;
+                timeFade = 1.0f - ((float)timeIntoFade / CombatEffects::DEATH_FINAL_FADE_DURATION_MS);
             } else {
-                timeFade = 0.0f; // Fully faded
+                timeFade = 0.0f;
             }
         }
     }
-
-    if (timeFade <= 0.0f) return; // Early exit if fully faded
-
-    // Apply time fade to overall alpha
+    if (timeFade <= 0.0f) return;
     fadeAlpha *= timeFade;
 
-    // --- Drawing ---
+    // --- 3. Draw Common Elements ---
     const float yOffset = RenderingLayout::STANDALONE_HEALTH_BAR_Y_OFFSET;
     ImVec2 barMin(centerPos.x - barWidth / 2, centerPos.y + yOffset);
     ImVec2 barMax(centerPos.x + barWidth / 2, centerPos.y + yOffset + barHeight);
-    float bgAlphaf = RenderingLayout::STANDALONE_HEALTH_BAR_BG_ALPHA * fadeAlpha;
-    unsigned int bgAlpha = static_cast<unsigned int>(bgAlphaf + 0.5f);
-    bgAlpha = (std::min)(bgAlpha, 255u);
+    unsigned int bgAlpha = static_cast<unsigned int>(RenderingLayout::STANDALONE_HEALTH_BAR_BG_ALPHA * fadeAlpha + 0.5f);
+    drawList->AddRectFilled(barMin, barMax, IM_COL32(0, 0, 0, (std::min)(bgAlpha, 255u)), RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
 
-    // --- Draw the Background (always visible, alive or dead) ---
-    drawList->AddRectFilled(barMin, barMax, IM_COL32(0, 0, 0, bgAlpha), RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-
-    // --- Handle Dead/Alive states ---
+    // --- 4. Delegate to the Correct Specialist ---
     if (state && state->deathTimestamp > 0) {
-        uint64_t timeSinceDeath = now - state->deathTimestamp;
-
-        // --- PHASE 1: THE ENERGY BURST ---
-        if (timeSinceDeath < CombatEffects::DEATH_BURST_DURATION_MS) {
-            float burstProgress = (float)timeSinceDeath / CombatEffects::DEATH_BURST_DURATION_MS;
-            float burstAlpha = 1.0f - burstProgress;
-            float burstWidth = barWidth * burstProgress; // Expands from 0 to full width
-            
-            ImU32 burstColor = IM_COL32(200, 255, 255, (int)(burstAlpha * 255));
-            ImVec2 centerPoint(barMin.x + barWidth * 0.5f, barMin.y + barHeight * 0.5f);
-
-            ImVec2 burstMin(centerPoint.x - burstWidth * 0.5f, barMin.y);
-            ImVec2 burstMax(centerPoint.x + burstWidth * 0.5f, barMax.y);
-            
-            drawList->AddRectFilled(burstMin, burstMax, burstColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-        }
-    }
-    // --- ELSE, ENTITY IS ALIVE: RENDER NORMAL HEALTH BAR ---
-    else {
-        if (!entity || entity->maxHealth <= 0) return;
-
-        // Health fill dimensions
-        float healthWidth = barWidth * context.healthPercent;
-        ImVec2 healthBarMin(barMin.x, barMin.y);
-        ImVec2 healthBarMax(barMin.x + healthWidth, barMax.y);
-        float healthAlphaf = RenderingLayout::STANDALONE_HEALTH_BAR_HEALTH_ALPHA * fadeAlpha;
-        unsigned int healthAlpha = static_cast<unsigned int>(healthAlphaf + 0.5f);
-        healthAlpha = (std::min)(healthAlpha, 255u);
-        unsigned int baseHealthColor = (entityColor & 0x00FFFFFF) | (healthAlpha << 24);
-
-        // --- Draw the BASE health fill (always draw the full bar in its normal color) ---
-        drawList->AddRectFilled(healthBarMin, healthBarMax, baseHealthColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-
-        if (!state) return;
-
-        // --- HEAL ABSORPTION OVERLAY LOGIC ---
-        if (state->lastHealTimestamp > 0 && (now - state->lastHealTimestamp < CombatEffects::HEAL_OVERLAY_DURATION_MS)) {
-            float healStartPercent = state->healStartHealth / entity->maxHealth;
-            float currentHealthPercent = entity->currentHealth / entity->maxHealth;
-            if (currentHealthPercent > healStartPercent) {
-                ImU32 healOverlayColor = IM_COL32(100, 255, 100, 200);
-                ImVec2 healOverlayMin(barMin.x + barWidth * healStartPercent, barMin.y);
-                ImVec2 healOverlayMax(barMin.x + barWidth * currentHealthPercent, barMax.y);
-                drawList->AddRectFilled(healOverlayMin, healOverlayMax, healOverlayColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-            }
-        }
-
-        // --- HEAL FLASH EVENT LOGIC ---
-        if (state->lastHealFlashTimestamp > 0 && (now - state->lastHealFlashTimestamp < CombatEffects::HEAL_FLASH_DURATION_MS)) {
-            uint64_t timeSinceHealFlash = now - state->lastHealFlashTimestamp;
-            float fadeProgress = (float)timeSinceHealFlash / CombatEffects::HEAL_FLASH_DURATION_MS;
-            float flashAlpha = 1.0f - fadeProgress;
-            ImU32 healFlashColor = IM_COL32(200, 255, 255, (int)(flashAlpha * 255));
-            float healStartPercent = state->healStartHealth / entity->maxHealth;
-            float currentHealthPercent = entity->currentHealth / entity->maxHealth;
-            if (currentHealthPercent > healStartPercent) {
-                ImVec2 healOverlayMin(barMin.x + barWidth * healStartPercent, barMin.y);
-                ImVec2 healOverlayMax(barMin.x + barWidth * currentHealthPercent, barMax.y);
-                drawList->AddRectFilled(healOverlayMin, healOverlayMax, healFlashColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-            }
-        }
-
-        // --- DAMAGE FLASH LOGIC ---
-        if (state->lastHitTimestamp > 0 && (now - state->lastHitTimestamp < CombatEffects::DAMAGE_FLASH_DURATION_MS)) {
-            uint64_t timeSinceHit = now - state->lastHitTimestamp;
-            float fadeProgress = (float)timeSinceHit / CombatEffects::DAMAGE_FLASH_DURATION_MS;
-            float flashAlpha = 1.0f - (fadeProgress * fadeProgress);
-            ImU32 flashColor = IM_COL32(255, 255, 0, (int)(flashAlpha * 255));
-            float currentHealthPercent = entity->currentHealth / entity->maxHealth;
-            float previousHealthPercent = (entity->currentHealth + state->lastDamageTaken) / entity->maxHealth;
-            ImVec2 flashMin = ImVec2(barMin.x + barWidth * currentHealthPercent, barMin.y);
-            ImVec2 flashMax = ImVec2(barMin.x + barWidth * (std::min)(1.0f, previousHealthPercent), barMax.y);
-            if (flashMin.x < flashMax.x) {
-                drawList->AddRectFilled(flashMin, flashMax, flashColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
-            }
-        }
+        RenderDeadState(drawList, state, barMin, barMax, barWidth, fadeAlpha);
+    } else {
+        RenderAliveState(drawList, context, state, barMin, barMax, barWidth, entityColor, fadeAlpha);
     }
 
-    // --- Draw the Border (always visible, alive or dead) ---
+    // --- 5. Draw Final Border ---
     if (context.attitude == Game::Attitude::Hostile) {
-        float borderAlphaf = RenderingLayout::STANDALONE_HEALTH_BAR_BORDER_ALPHA * fadeAlpha;
-        unsigned int borderAlpha = static_cast<unsigned int>(borderAlphaf + 0.5f);
-        borderAlpha = (std::min)(borderAlpha, 255u);
-        drawList->AddRect(barMin, barMax, IM_COL32(0, 0, 0, borderAlpha), 
-                         RenderingLayout::STANDALONE_HEALTH_BAR_BORDER_ROUNDING, 0, 
+        unsigned int borderAlpha = static_cast<unsigned int>(RenderingLayout::STANDALONE_HEALTH_BAR_BORDER_ALPHA * fadeAlpha + 0.5f);
+        drawList->AddRect(barMin, barMax, IM_COL32(0, 0, 0, (std::min)(borderAlpha, 255u)), 
+                         RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING, 0, 
                          RenderingLayout::STANDALONE_HEALTH_BAR_BORDER_THICKNESS);
+    }
+}
+
+// --- NEW, SPECIALIST HELPER FUNCTIONS ---
+
+void ESPHealthBarRenderer::RenderAliveState(ImDrawList* drawList, const EntityRenderContext& context, const EntityCombatState* state,
+                                            const ImVec2& barMin, const ImVec2& barMax, float barWidth, unsigned int entityColor, float fadeAlpha) {
+    const RenderableEntity* entity = context.entity;
+    if (!entity || entity->maxHealth <= 0) return;
+
+    // Calculate base color
+    float healthWidth = barWidth * context.healthPercent;
+    ImVec2 healthBarMin = barMin;
+    ImVec2 healthBarMax(barMin.x + healthWidth, barMax.y);
+    unsigned int healthAlpha = static_cast<unsigned int>(RenderingLayout::STANDALONE_HEALTH_BAR_HEALTH_ALPHA * fadeAlpha + 0.5f);
+    unsigned int baseHealthColor = (entityColor & 0x00FFFFFF) | ((std::min)(healthAlpha, 255u) << 24);
+
+    // Draw base health fill
+    drawList->AddRectFilled(healthBarMin, healthBarMax, baseHealthColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
+    
+    if (!state) return; // No state, no effects
+    uint64_t now = GetTickCount64();
+
+    // Render Heal Absorption Overlay
+    if (state->lastHealTimestamp > 0 && (now - state->lastHealTimestamp < CombatEffects::HEAL_OVERLAY_DURATION_MS)) {
+        float healStartPercent = state->healStartHealth / entity->maxHealth;
+        float currentHealthPercent = entity->currentHealth / entity->maxHealth;
+        if (currentHealthPercent > healStartPercent) {
+            ImU32 healOverlayColor = IM_COL32(100, 255, 100, 200);
+            ImVec2 healOverlayMin(barMin.x + barWidth * healStartPercent, barMin.y);
+            ImVec2 healOverlayMax(barMin.x + barWidth * currentHealthPercent, barMax.y);
+            drawList->AddRectFilled(healOverlayMin, healOverlayMax, healOverlayColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
+        }
+    }
+
+    // Render Heal Flash
+    if (state->lastHealFlashTimestamp > 0 && (now - state->lastHealFlashTimestamp < CombatEffects::HEAL_FLASH_DURATION_MS)) {
+        uint64_t timeSinceHealFlash = now - state->lastHealFlashTimestamp;
+        float fadeProgress = (float)timeSinceHealFlash / CombatEffects::HEAL_FLASH_DURATION_MS;
+        float flashAlpha = 1.0f - fadeProgress;
+        ImU32 healFlashColor = IM_COL32(200, 255, 255, (int)(flashAlpha * 255));
+        float healStartPercent = state->healStartHealth / entity->maxHealth;
+        float currentHealthPercent = entity->currentHealth / entity->maxHealth;
+        if (currentHealthPercent > healStartPercent) {
+            ImVec2 healOverlayMin(barMin.x + barWidth * healStartPercent, barMin.y);
+            ImVec2 healOverlayMax(barMin.x + barWidth * currentHealthPercent, barMax.y);
+            drawList->AddRectFilled(healOverlayMin, healOverlayMax, healFlashColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
+        }
+    }
+
+    // Render Damage Flash
+    if (state->lastHitTimestamp > 0 && (now - state->lastHitTimestamp < CombatEffects::DAMAGE_FLASH_DURATION_MS)) {
+        uint64_t timeSinceHit = now - state->lastHitTimestamp;
+        float fadeProgress = (float)timeSinceHit / CombatEffects::DAMAGE_FLASH_DURATION_MS;
+        float flashAlpha = 1.0f - (fadeProgress * fadeProgress);
+        ImU32 flashColor = IM_COL32(255, 255, 0, (int)(flashAlpha * 255));
+        float currentHealthPercent = entity->currentHealth / entity->maxHealth;
+        float previousHealthPercent = (entity->currentHealth + state->lastDamageTaken) / entity->maxHealth;
+        ImVec2 flashMin = ImVec2(barMin.x + barWidth * currentHealthPercent, barMin.y);
+        ImVec2 flashMax = ImVec2(barMin.x + barWidth * (std::min)(1.0f, previousHealthPercent), barMax.y);
+        if (flashMin.x < flashMax.x) {
+            drawList->AddRectFilled(flashMin, flashMax, flashColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
+        }
+    }
+}
+
+void ESPHealthBarRenderer::RenderDeadState(ImDrawList* drawList, const EntityCombatState* state,
+                                           const ImVec2& barMin, const ImVec2& barMax, float barWidth, float fadeAlpha) {
+    uint64_t now = GetTickCount64();
+    uint64_t timeSinceDeath = now - state->deathTimestamp;
+
+    // Render Energy Burst
+    if (timeSinceDeath < CombatEffects::DEATH_BURST_DURATION_MS) {
+        float burstProgress = (float)timeSinceDeath / CombatEffects::DEATH_BURST_DURATION_MS;
+        float burstAlpha = 1.0f - burstProgress;
+        float currentBurstWidth = barWidth * burstProgress; // Expands from 0 to full width
+        ImU32 burstColor = IM_COL32(200, 255, 255, (int)(burstAlpha * 255));
+        float barHeight = barMax.y - barMin.y;
+        
+        ImVec2 centerPoint(barMin.x + barWidth * 0.5f, barMin.y + barHeight * 0.5f);
+        ImVec2 burstMin(centerPoint.x - currentBurstWidth * 0.5f, barMin.y);
+        ImVec2 burstMax(centerPoint.x + currentBurstWidth * 0.5f, barMax.y);
+        
+        drawList->AddRectFilled(burstMin, burstMax, burstColor, RenderingLayout::STANDALONE_HEALTH_BAR_BG_ROUNDING);
     }
 }
 

--- a/src/Rendering/Renderers/ESPHealthBarRenderer.h
+++ b/src/Rendering/Renderers/ESPHealthBarRenderer.h
@@ -7,6 +7,10 @@
 
 namespace kx {
 
+// Forward declarations
+class CombatStateManager;
+struct EntityRenderContext;
+
 /**
  * @brief Utility functions for rendering health bars
  * 
@@ -23,13 +27,12 @@ public:
      * @param entityColor Entity color (contains alpha for distance fading)
      * @param barWidth Width of the health bar
      * @param barHeight Height of the health bar
-     * @param entityType Type of entity (Player/NPC/Gadget) - determines color scheme
-     * @param attitude Entity attitude (Hostile/Friendly/Neutral) - for NPCs
+     * @param stateManager Reference to the combat state manager for damage flash effects
      */
     static void RenderStandaloneHealthBar(ImDrawList* drawList, const glm::vec2& centerPos,
-                                         float healthPercent, unsigned int entityColor, 
+                                         const EntityRenderContext& context, unsigned int entityColor, 
                                          float barWidth, float barHeight,
-                                         ESPEntityType entityType, Game::Attitude attitude = Game::Attitude::Neutral);
+                                         const CombatStateManager& stateManager);
 
     /**
      * @brief Render a standalone energy bar below the health bar

--- a/src/Rendering/Renderers/ESPHealthBarRenderer.h
+++ b/src/Rendering/Renderers/ESPHealthBarRenderer.h
@@ -7,9 +7,10 @@
 
 namespace kx {
 
-// Forward declarations
-class CombatStateManager;
-struct EntityRenderContext;
+	// Forward declarations
+	class CombatStateManager;
+	struct EntityRenderContext;
+	struct EntityCombatState;
 
 /**
  * @brief Utility functions for rendering health bars
@@ -47,6 +48,15 @@ public:
     static void RenderStandaloneEnergyBar(ImDrawList* drawList, const glm::vec2& centerPos,
                                          float energyPercent, float fadeAlpha,
                                          float barWidth, float barHeight, float healthBarHeight);
+
+private:
+    // Specialist function for rendering a living entity's health bar and effects
+    static void RenderAliveState(ImDrawList* drawList, const EntityRenderContext& context, const EntityCombatState* state,
+                                 const ImVec2& barMin, const ImVec2& barMax, float barWidth, unsigned int entityColor, float fadeAlpha);
+
+    // Specialist function for rendering the death animation
+    static void RenderDeadState(ImDrawList* drawList, const EntityCombatState* state,
+                                const ImVec2& barMin, const ImVec2& barMax, float barWidth, float fadeAlpha);
 };
 
 } // namespace kx

--- a/src/Rendering/Utils/ESPConstants.h
+++ b/src/Rendering/Utils/ESPConstants.h
@@ -8,6 +8,7 @@ namespace kx {
         constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 220;
         constexpr uint64_t HEAL_FLASH_DURATION_MS = 150;
         constexpr uint64_t HEAL_OVERLAY_DURATION_MS = 2000;
+        constexpr uint64_t BURST_HEAL_WINDOW_MS = 350; // <-- ADD THIS CONSTANT
         constexpr uint64_t STATE_CLEANUP_THRESHOLD_MS = 3000;
     }
 

--- a/src/Rendering/Utils/ESPConstants.h
+++ b/src/Rendering/Utils/ESPConstants.h
@@ -4,6 +4,13 @@
 
 namespace kx {
 
+namespace CombatEffects {
+    constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 250;
+    constexpr uint64_t HEAL_PULSE_DURATION_MS = 400;
+    constexpr uint64_t STATE_CLEANUP_THRESHOLD_MS = 5000;
+}
+
+
 /**
  * @brief Minimum size constraints for entity visibility
  * 

--- a/src/Rendering/Utils/ESPConstants.h
+++ b/src/Rendering/Utils/ESPConstants.h
@@ -5,9 +5,8 @@
 namespace kx {
 
     namespace CombatEffects {
-        constexpr uint64_t DEATH_SHATTER_DURATION_MS = 500;
-        constexpr uint64_t DEATH_EMBER_FADE_DURATION_MS = 1000;
-        constexpr uint64_t DEATH_FINAL_FADE_DURATION_MS = 1000;
+        constexpr uint64_t DEATH_BURST_DURATION_MS = 1000;     // A quick energy burst
+        constexpr uint64_t DEATH_FINAL_FADE_DURATION_MS = 1000;  // Bar fades out over x seconds after burst
         constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 220;
         constexpr uint64_t HEAL_FLASH_DURATION_MS = 150;
         constexpr uint64_t HEAL_OVERLAY_DURATION_MS = 2000;

--- a/src/Rendering/Utils/ESPConstants.h
+++ b/src/Rendering/Utils/ESPConstants.h
@@ -4,12 +4,12 @@
 
 namespace kx {
 
-namespace CombatEffects {
-    constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 250;
-    constexpr uint64_t HEAL_PULSE_DURATION_MS = 400;
-    constexpr uint64_t STATE_CLEANUP_THRESHOLD_MS = 5000;
-}
-
+    namespace CombatEffects {
+        constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 220;
+        constexpr uint64_t HEAL_FLASH_DURATION_MS = 150;
+        constexpr uint64_t HEAL_OVERLAY_DURATION_MS = 2000;
+        constexpr uint64_t STATE_CLEANUP_THRESHOLD_MS = 3000;
+    }
 
 /**
  * @brief Minimum size constraints for entity visibility

--- a/src/Rendering/Utils/ESPConstants.h
+++ b/src/Rendering/Utils/ESPConstants.h
@@ -5,10 +5,13 @@
 namespace kx {
 
     namespace CombatEffects {
+        constexpr uint64_t DEATH_SHATTER_DURATION_MS = 500;
+        constexpr uint64_t DEATH_EMBER_FADE_DURATION_MS = 1000;
+        constexpr uint64_t DEATH_FINAL_FADE_DURATION_MS = 1000;
         constexpr uint64_t DAMAGE_FLASH_DURATION_MS = 220;
         constexpr uint64_t HEAL_FLASH_DURATION_MS = 150;
         constexpr uint64_t HEAL_OVERLAY_DURATION_MS = 2000;
-        constexpr uint64_t BURST_HEAL_WINDOW_MS = 350; // <-- ADD THIS CONSTANT
+        constexpr uint64_t BURST_HEAL_WINDOW_MS = 350;
         constexpr uint64_t STATE_CLEANUP_THRESHOLD_MS = 3000;
     }
 


### PR DESCRIPTION
This PR transforms the static health bars into a dynamic, combat-aware tactical feature by tracking real-time health changes. It introduces a `CombatStateManager` to manage entity state between frames, enabling sophisticated visual feedback for key combat events.

**Key Enhancements:**

*   **Damage Flash:** An immediate, high-contrast yellow flash appears on the "lost health" segment of the bar upon taking damage, providing instant hit confirmation.
*   **Healing Visuals (Hybrid Flash + Overlay):**
    *   A snappy, bright cyan flash signals the *event* of a heal.
    *   A persistent green "absorption" overlay visualizes the *magnitude* of the heal, providing crucial tactical information for target switching.
*   **Thematic Death Animation ("Energy Burst"):**
    *   Replaces the old instant-disappear with a thematic energy burst animation upon death, serving as a clear "target down" confirmation.
    *   The health bar now gracefully fades out after the animation completes.
*   **Animation-Aware Filtering:** The `ESPFilter` has been updated to keep dead entities on screen for the duration of their death animation, even when `showDeadNpcs` is disabled, ensuring a smooth visual experience.

This change significantly increases the tactical value of the overlay by providing at-a-glance intelligence on focus fire, healing, and target deaths, moving the health bar from a simple data display to a true combat status indicator.