### PR TITLE
Add filter for show detail feature

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -40,6 +40,17 @@ namespace kx {
         bool showHostile = true;
         bool showNeutral = true;
         bool showIndifferent = true;
+
+		// Detail-field filters
+        bool showDetailLevel = true;
+        bool showDetailHp = true;
+        bool showDetailAttitude = true;
+        bool showDetailEnergy = true;
+		bool showDetailPosition = true;
+		bool showDetailRank = true;
+		bool showDetailProfession = true;
+		bool showDetailRace = true;
+		bool showDetailName = true;
     };
 
     struct NpcEspSettings {

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -104,6 +104,13 @@ namespace kx {
         bool showRifts = true;            // Type 13
         bool showGeneric = false;         // Type 3
         bool showUnknown = true;          // For any type not explicitly handled
+
+		// Detail-field filters
+		bool showDetailGadgetType = true;
+		bool showDetailHealth = true;
+        bool showDetailPosition = true;
+        bool showDetailResourceInfo = true;
+		bool showDetailGatherableStatus = true;
     };
 
     // --- User-configurable settings ---

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -56,6 +56,12 @@ namespace kx {
         bool showIndifferent = true;
         // Health-based filtering
         bool showDeadNpcs = false;  // Show NPCs with 0 HP (dead/defeated enemies)
+        // Detail-field filters
+        bool showDetailLevel = true;
+        bool showDetailHp = true;
+        bool showDetailAttitude = true;
+        bool showDetailRank = true;
+        bool showDetailPosition = true;
         // Add specific colors
         // ColorRGBA friendlyColor = { 0, 255, 100, 220 };
         // etc.

--- a/src/Rendering/GUI/NpcsTab.cpp
+++ b/src/Rendering/GUI/NpcsTab.cpp
@@ -31,6 +31,19 @@ namespace kx {
                     }
 
                     ImGui::Separator();
+                    if (ImGui::CollapsingHeader("NPC Details Filter")) {
+                        ImGui::Checkbox("Level", &settings.npcESP.showDetailLevel);
+                        ImGui::SameLine();
+                        ImGui::Checkbox("HP", &settings.npcESP.showDetailHp);
+                        ImGui::SameLine();
+                        ImGui::Checkbox("Attitude", &settings.npcESP.showDetailAttitude);
+                        ImGui::SameLine();
+                        ImGui::Checkbox("Rank", &settings.npcESP.showDetailRank);
+                        ImGui::SameLine();
+                        ImGui::Checkbox("Pos", &settings.npcESP.showDetailPosition);
+                    }
+
+                    ImGui::Separator();
                     RenderCategoryStyleSettings("NPC Style", settings.npcESP.renderBox, settings.npcESP.renderDistance, settings.npcESP.renderDot, &settings.npcESP.renderHealthBar, nullptr, &settings.npcESP.renderDetails);
                 }
                 ImGui::EndTabItem();

--- a/src/Rendering/GUI/NpcsTab.cpp
+++ b/src/Rendering/GUI/NpcsTab.cpp
@@ -31,20 +31,22 @@ namespace kx {
                     }
 
                     ImGui::Separator();
-                    if (ImGui::CollapsingHeader("NPC Details Filter")) {
-                        ImGui::Checkbox("Level", &settings.npcESP.showDetailLevel);
-                        ImGui::SameLine();
-                        ImGui::Checkbox("HP", &settings.npcESP.showDetailHp);
-                        ImGui::SameLine();
-                        ImGui::Checkbox("Attitude", &settings.npcESP.showDetailAttitude);
-                        ImGui::SameLine();
-                        ImGui::Checkbox("Rank", &settings.npcESP.showDetailRank);
-                        ImGui::SameLine();
-                        ImGui::Checkbox("Pos", &settings.npcESP.showDetailPosition);
-                    }
-
-                    ImGui::Separator();
                     RenderCategoryStyleSettings("NPC Style", settings.npcESP.renderBox, settings.npcESP.renderDistance, settings.npcESP.renderDot, &settings.npcESP.renderHealthBar, nullptr, &settings.npcESP.renderDetails);
+
+                    if (settings.npcESP.renderDetails) {
+                        ImGui::Separator();
+                        if (ImGui::CollapsingHeader("NPC Details Filter")) {
+                            ImGui::Checkbox("Level", &settings.npcESP.showDetailLevel);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("HP", &settings.npcESP.showDetailHp);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Attitude", &settings.npcESP.showDetailAttitude);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Rank", &settings.npcESP.showDetailRank);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Pos", &settings.npcESP.showDetailPosition);
+                        }
+                    }
                 }
                 ImGui::EndTabItem();
             }

--- a/src/Rendering/GUI/ObjectsTab.cpp
+++ b/src/Rendering/GUI/ObjectsTab.cpp
@@ -114,6 +114,18 @@ namespace kx {
 
                         ImGui::SeparatorText("Informational Overlays");
                         CheckboxWithTooltip("Show Details", "ObjectStyle", &settings.objectESP.renderDetails, "Show detailed information like the object type.");
+                        if (settings.objectESP.renderDetails) {
+                            if (ImGui::CollapsingHeader("Object Details Filters")) {
+                                CheckboxWithTooltip("Type", "ObjectDetails", &settings.objectESP.showDetailGadgetType, "Show the type of gadget (e.g., Resource Node, Waypoint).");
+                                ImGui::SameLine(column1);
+                                CheckboxWithTooltip("HP", "ObjectDetails", &settings.objectESP.showDetailHealth, "Show current and maximum health if applicable.");
+                                ImGui::SameLine(column2);
+                                CheckboxWithTooltip("Pos", "ObjectDetails", &settings.objectESP.showDetailPosition, "Show the object's world coordinates.");
+                                CheckboxWithTooltip("Node Type", "ObjectDetails", &settings.objectESP.showDetailResourceInfo, "Show resource node type.");
+                                ImGui::SameLine(column1);
+                                CheckboxWithTooltip("Status", "ObjectDetails", &settings.objectESP.showDetailGatherableStatus, "Show if a resource node is currently gatherable.");
+							}
+						}
                     }
                 }
                 ImGui::EndTabItem();

--- a/src/Rendering/GUI/PlayersTab.cpp
+++ b/src/Rendering/GUI/PlayersTab.cpp
@@ -47,24 +47,28 @@ namespace kx {
                     ImGui::PopItemWidth();
 
                     ImGui::Separator();
-					if (ImGui::CollapsingHeader("Player Details Filter"))
-                    {
-					    ImGui::Checkbox("Level", &settings.playerESP.showDetailLevel);
-					    ImGui::SameLine();
-					    ImGui::Checkbox("Prof", &settings.playerESP.showDetailProfession);
-					    ImGui::SameLine();
-					    ImGui::Checkbox("Attitude", &settings.playerESP.showDetailAttitude);
-					    ImGui::SameLine();
-					    ImGui::Checkbox("Race", &settings.playerESP.showDetailRace);
-					    ImGui::Checkbox("HP", &settings.playerESP.showDetailHp);
-					    ImGui::SameLine();
-					    ImGui::Checkbox("Energy", &settings.playerESP.showDetailEnergy);
-					    ImGui::SameLine();
-					    ImGui::Checkbox("Pos", &settings.playerESP.showDetailPosition);
-					}
-
-                    ImGui::Separator();
                     RenderCategoryStyleSettings("Player Style", settings.playerESP.renderBox, settings.playerESP.renderDistance, settings.playerESP.renderDot, &settings.playerESP.renderHealthBar, &settings.playerESP.renderEnergyBar, &settings.playerESP.renderDetails, &settings.playerESP.renderPlayerName);
+
+                    if (settings.playerESP.renderDetails) {
+                        ImGui::Separator();
+                        if (ImGui::CollapsingHeader("Player Details Filter"))
+                        {
+							ImGui::Checkbox("Name", &settings.playerESP.showDetailName);
+							ImGui::SameLine();
+							ImGui::Checkbox("Level", &settings.playerESP.showDetailLevel);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Prof", &settings.playerESP.showDetailProfession);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Attitude", &settings.playerESP.showDetailAttitude);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Race", &settings.playerESP.showDetailRace);
+                            ImGui::Checkbox("HP", &settings.playerESP.showDetailHp);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Energy", &settings.playerESP.showDetailEnergy);
+                            ImGui::SameLine();
+                            ImGui::Checkbox("Pos", &settings.playerESP.showDetailPosition);
+                        }
+                    }
                 }
                 ImGui::EndTabItem();
             }

--- a/src/Rendering/GUI/PlayersTab.cpp
+++ b/src/Rendering/GUI/PlayersTab.cpp
@@ -47,6 +47,23 @@ namespace kx {
                     ImGui::PopItemWidth();
 
                     ImGui::Separator();
+					if (ImGui::CollapsingHeader("Player Details Filter"))
+                    {
+					    ImGui::Checkbox("Level", &settings.playerESP.showDetailLevel);
+					    ImGui::SameLine();
+					    ImGui::Checkbox("Prof", &settings.playerESP.showDetailProfession);
+					    ImGui::SameLine();
+					    ImGui::Checkbox("Attitude", &settings.playerESP.showDetailAttitude);
+					    ImGui::SameLine();
+					    ImGui::Checkbox("Race", &settings.playerESP.showDetailRace);
+					    ImGui::Checkbox("HP", &settings.playerESP.showDetailHp);
+					    ImGui::SameLine();
+					    ImGui::Checkbox("Energy", &settings.playerESP.showDetailEnergy);
+					    ImGui::SameLine();
+					    ImGui::Checkbox("Pos", &settings.playerESP.showDetailPosition);
+					}
+
+                    ImGui::Separator();
                     RenderCategoryStyleSettings("Player Style", settings.playerESP.renderBox, settings.playerESP.renderDistance, settings.playerESP.renderDot, &settings.playerESP.renderHealthBar, &settings.playerESP.renderEnergyBar, &settings.playerESP.renderDetails, &settings.playerESP.renderPlayerName);
                 }
                 ImGui::EndTabItem();

--- a/src/Rendering/Utils/ESPEntityDetailsBuilder.cpp
+++ b/src/Rendering/Utils/ESPEntityDetailsBuilder.cpp
@@ -20,28 +20,35 @@ std::vector<ColoredDetail> ESPEntityDetailsBuilder::BuildNpcDetails(const Render
         details.push_back({ "NPC: " + npc->name, ESPColors::DEFAULT_TEXT });
     }
 
-    if (npc->level > 0) {
+    if (settings.showDetailLevel && npc->level > 0) {
         details.push_back({ "Level: " + std::to_string(npc->level), ESPColors::DEFAULT_TEXT });
     }
 
-    if (npc->maxHealth > 0) {
+    if (settings.showDetailHp && npc->maxHealth > 0) {
         details.push_back({ "HP: " + std::to_string(static_cast<int>(npc->currentHealth)) + "/" + std::to_string(static_cast<int>(npc->maxHealth)), ESPColors::DEFAULT_TEXT });
     }
 
-    const char* attitudeName = ESPFormatting::GetAttitudeName(npc->attitude);
-    details.push_back({ "Attitude: " + (attitudeName ? std::string(attitudeName) : "ID: " + std::to_string(static_cast<uint32_t>(npc->attitude))), ESPColors::DEFAULT_TEXT });
-    
-    const char* rankName = ESPFormatting::GetRankName(npc->rank);
-    if (rankName && rankName[0] != '\0') {
-        details.push_back({ "Rank: " + std::string(rankName), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailAttitude) {
+        const char* attitudeName = ESPFormatting::GetAttitudeName(npc->attitude);
+        details.push_back({ "Attitude: " + (attitudeName ? std::string(attitudeName) : "ID: " + std::to_string(static_cast<uint32_t>(npc->attitude))), ESPColors::DEFAULT_TEXT });
     }
 
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1)
-        << "Pos: (" << npc->position.x
-        << ", " << npc->position.y
-        << ", " << npc->position.z << ")";
-    details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailRank) {
+        const char* rankName = ESPFormatting::GetRankName(npc->rank);
+        if (rankName && rankName[0] != '\0') {
+            details.push_back({ "Rank: " + std::string(rankName), ESPColors::DEFAULT_TEXT });
+        }
+    }
+
+    if (settings.showDetailPosition) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(1)
+            << "Pos: (" << npc->position.x
+            << ", " << npc->position.y
+            << ", " << npc->position.z << ")";
+        details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    }
+
 
     if (showDebugAddresses) {
         char addrStr[32];

--- a/src/Rendering/Utils/ESPEntityDetailsBuilder.cpp
+++ b/src/Rendering/Utils/ESPEntityDetailsBuilder.cpp
@@ -68,27 +68,31 @@ std::vector<ColoredDetail> ESPEntityDetailsBuilder::BuildGadgetDetails(const Ren
 
     details.reserve(8); // Future-proof: generous reserve for adding new fields
 
-    const char* gadgetName = ESPFormatting::GetGadgetTypeName(gadget->type);
-    details.push_back({ "Type: " + (gadgetName ? std::string(gadgetName) : "ID: " + std::to_string(static_cast<uint32_t>(gadget->type))), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailGadgetType) {
+        const char* gadgetName = ESPFormatting::GetGadgetTypeName(gadget->type);
+        details.push_back({ "Type: " + (gadgetName ? std::string(gadgetName) : "ID: " + std::to_string(static_cast<uint32_t>(gadget->type))), ESPColors::DEFAULT_TEXT });
+    }
 
-    if (gadget->maxHealth > 0) {
+    if (settings.showDetailHealth && gadget->maxHealth > 0) {
         details.push_back({ "HP: " + std::to_string(static_cast<int>(gadget->currentHealth)) + "/" + std::to_string(static_cast<int>(gadget->maxHealth)), ESPColors::DEFAULT_TEXT });
     }
 
-    if (gadget->type == Game::GadgetType::ResourceNode) {
+    if (settings.showDetailResourceInfo && gadget->type == Game::GadgetType::ResourceNode) {
         details.push_back({ "Node: " + ESPFormatting::ResourceNodeTypeToString(gadget->resourceType), ESPColors::DEFAULT_TEXT });
     }
 
-    if (gadget->isGatherable) {
+    if (settings.showDetailGatherableStatus && gadget->isGatherable) {
         details.push_back({ "Status: Gatherable", ESPColors::DEFAULT_TEXT });
     }
 
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1)
-        << "Pos: (" << gadget->position.x
-        << ", " << gadget->position.y
-        << ", " << gadget->position.z << ")";
-    details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailPosition) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(1)
+            << "Pos: (" << gadget->position.x
+            << ", " << gadget->position.y
+            << ", " << gadget->position.z << ")";
+        details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    }
 
     if (showDebugAddresses) {
         char addrStr[32];

--- a/src/Rendering/Utils/ESPPlayerDetailsBuilder.cpp
+++ b/src/Rendering/Utils/ESPPlayerDetailsBuilder.cpp
@@ -22,11 +22,11 @@ std::vector<ColoredDetail> ESPPlayerDetailsBuilder::BuildPlayerDetails(const Ren
     
     details.reserve(16); // Future-proof: generous reserve for adding new fields
 
-    if (!player->playerName.empty()) {
+    if (settings.showDetailName && !player->playerName.empty()) {
         details.push_back({ "Player: " + player->playerName, ESPColors::DEFAULT_TEXT });
     }
 
-    if (player->level > 0) {
+    if (settings.showDetailLevel && player->level > 0) {
         std::string levelText = "Level: " + std::to_string(player->level);
         if (player->scaledLevel != player->level && player->scaledLevel > 0) {
             levelText += " (" + std::to_string(player->scaledLevel) + ")";
@@ -34,35 +34,39 @@ std::vector<ColoredDetail> ESPPlayerDetailsBuilder::BuildPlayerDetails(const Ren
         details.push_back({ levelText, ESPColors::DEFAULT_TEXT });
     }
 
-    if (player->profession != Game::Profession::None) {
+    if (settings.showDetailProfession && player->profession != Game::Profession::None) {
         const char* profName = ESPFormatting::GetProfessionName(player->profession);
         details.push_back({ "Prof: " + (profName ? std::string(profName) : "ID: " + std::to_string(static_cast<uint32_t>(player->profession))), ESPColors::DEFAULT_TEXT });
     }
 
     // Display player attitude
-    const char* attitudeName = ESPFormatting::GetAttitudeName(player->attitude);
-    details.push_back({ "Attitude: " + (attitudeName ? std::string(attitudeName) : "Unknown"), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailAttitude) {
+        const char* attitudeName = ESPFormatting::GetAttitudeName(player->attitude);
+        details.push_back({ "Attitude: " + (attitudeName ? std::string(attitudeName) : "Unknown"), ESPColors::DEFAULT_TEXT });
+	}
 
-    if (player->race != Game::Race::None) {
+    if (settings.showDetailRace && player->race != Game::Race::None) {
         const char* raceName = ESPFormatting::GetRaceName(player->race);
         details.push_back({ "Race: " + (raceName ? std::string(raceName) : "ID: " + std::to_string(static_cast<uint8_t>(player->race))), ESPColors::DEFAULT_TEXT });
     }
 
-    if (player->maxHealth > 0) {
+    if (settings.showDetailHp && player->maxHealth > 0) {
         details.push_back({ "HP: " + std::to_string(static_cast<int>(player->currentHealth)) + "/" + std::to_string(static_cast<int>(player->maxHealth)), ESPColors::DEFAULT_TEXT });
     }
 
-    if (player->maxEnergy > 0) {
+    if (settings.showDetailEnergy && player->maxEnergy > 0) {
         const int energyPercent = static_cast<int>((player->currentEnergy / player->maxEnergy) * 100.0f);
         details.push_back({ "Energy: " + std::to_string(static_cast<int>(player->currentEnergy)) + "/" + std::to_string(static_cast<int>(player->maxEnergy)) + " (" + std::to_string(energyPercent) + "%)", ESPColors::DEFAULT_TEXT });
     }
 
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1)
-        << "Pos: (" << player->position.x
-        << ", " << player->position.y
-        << ", " << player->position.z << ")";
-    details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    if (settings.showDetailPosition) {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(1)
+            << "Pos: (" << player->position.x
+            << ", " << player->position.y
+            << ", " << player->position.z << ")";
+        details.push_back({ oss.str(), ESPColors::DEFAULT_TEXT });
+    }
 
     if (showDebugAddresses) {
         char addrStr[32];


### PR DESCRIPTION
Added a filter option for players, NPC and object details for better visibility and customization.

<img width="885" height="298" alt="{3130E850-5276-4806-AAC8-088BAE52C1DA}" src="https://github.com/user-attachments/assets/478b33b1-3d0f-4219-9908-2d315d393c1a" />

<img width="858" height="323" alt="{4E15B602-1E6A-41BF-BE34-C6DCA2CBC526}" src="https://github.com/user-attachments/assets/71242711-2ff4-4054-b415-f216370362dd" />

<img width="966" height="150" alt="{547CA840-CF51-49A5-88BC-98240DDCB299}" src="https://github.com/user-attachments/assets/15ce6234-10af-4c34-b835-7f2cfdcd079f" />

